### PR TITLE
refactor(settings): 优化 SQL保留天数设置逻辑

### DIFF
--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/setting/DebugToolsSettingConfigurable.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/setting/DebugToolsSettingConfigurable.java
@@ -25,8 +25,6 @@ import io.github.future0923.debug.tools.base.enums.PrintSqlType;
 import io.github.future0923.debug.tools.base.hutool.core.util.BooleanUtil;
 import io.github.future0923.debug.tools.base.hutool.core.util.ObjectUtil;
 import io.github.future0923.debug.tools.common.dto.TraceMethodDTO;
-import io.github.future0923.debug.tools.idea.tool.DebugToolsToolWindow;
-import io.github.future0923.debug.tools.idea.tool.DebugToolsToolWindowFactory;
 import io.github.future0923.debug.tools.idea.ui.setting.SettingPanel;
 import io.github.future0923.debug.tools.idea.utils.DebugToolsNotifierUtil;
 import org.jetbrains.annotations.Nls;
@@ -34,6 +32,8 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.Objects;
+import io.github.future0923.debug.tools.idea.tool.DebugToolsToolWindowFactory;
+import io.github.future0923.debug.tools.idea.tool.DebugToolsToolWindow;
 
 /**
  * @author future0923
@@ -201,7 +201,7 @@ public class DebugToolsSettingConfigurable implements Configurable {
         settingState.setRemoveContextPath(settingPanel.getRemoveContextPath().getText());
 
         settingState.setAutoSaveSql(settingPanel.getSaveSqlCheckBox().isSelected());
-        settingState.setSqlRetentionDays(settingPanel.getSaveSqlDaysField().getNumber());
+        settingState.setSqlRetentionDays(Math.max(1,settingPanel.getSaveSqlDaysField().getNumber()));
 
         DebugToolsToolWindow toolWindow = DebugToolsToolWindowFactory.getToolWindow(project);
         if (toolWindow != null) {

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/setting/SettingPanel.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/setting/SettingPanel.java
@@ -120,7 +120,7 @@ public class SettingPanel {
         JPanel sqlRetentionPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 5));
         sqlRetentionPanel.add(new JLabel("SQL Retention Days:"));
         sqlRetentionPanel.add(saveSqlDaysField);
-        sqlRetentionPanel.add(new JLabel("0 means only keep SQL for the current request."));
+        sqlRetentionPanel.add(new JLabel("The minimum settable value is 1"));
 
         saveSqlCheckBox.setVisible(!printNoSql.isSelected());
         saveSqlCheckBox.setSelected(BooleanUtil.isTrue(settingState.getAutoSaveSql()));


### PR DESCRIPTION
-将 SQL 保留天数的最小值限制为 1 天- 更新设置界面提示文本，明确最小可设置值为 1