### PR TITLE
feat(mybatis):支持dynamic-datasource3.+版本(#32)

### DIFF
--- a/debug-tools-hotswap/debug-tools-hotswap-plugin/debug-tools-hotswap-mybatis-plugin/src/main/java/io/github/future0923/debug/tools/hotswap/core/plugin/mybatis/patch/DynamicPatcher.java
+++ b/debug-tools-hotswap/debug-tools-hotswap-plugin/debug-tools-hotswap-mybatis-plugin/src/main/java/io/github/future0923/debug/tools/hotswap/core/plugin/mybatis/patch/DynamicPatcher.java
@@ -52,19 +52,34 @@ public class DynamicPatcher {
                     "   return ds;" +
                     "}");
         } catch (NotFoundException e) {
-            // ds 4.2+
-            CtMethod findKey = ctClass.getDeclaredMethod("findKey", new CtClass[]{methodCtClass, objectCtClass, classCtClass});
-            findKey.setBody("{" +
-                    "   if ($1.getDeclaringClass() == java.lang.Object.class) {" +
-                    "       return \"\";" +
-                    "   }" +
-                    "   com.baomidou.dynamic.datasource.annotation.BasicAttribute dsOperation = this.computeDatasource($1, $2, $3);" +
-                    "   if (dsOperation == null) {" +
-                    "       return \"\";" +
-                    "   } else {" +
-                    "       return (java.lang.String) dsOperation.getDataOperation();" +
-                    "   }" +
-                    "}");
+            try {
+                // ds 4.2+
+                CtMethod findKey = ctClass.getDeclaredMethod("findKey", new CtClass[]{methodCtClass, objectCtClass, classCtClass});
+                findKey.setBody("{" +
+                        "   if ($1.getDeclaringClass() == java.lang.Object.class) {" +
+                        "       return \"\";" +
+                        "   }" +
+                        "   com.baomidou.dynamic.datasource.annotation.BasicAttribute dsOperation = this.computeDatasource($1, $2, $3);" +
+                        "   if (dsOperation == null) {" +
+                        "       return \"\";" +
+                        "   } else {" +
+                        "       return (java.lang.String) dsOperation.getDataOperation();" +
+                        "   }" +
+                        "}");
+            } catch (NotFoundException ex) {
+                // ds 3+
+                CtMethod findDSKey = ctClass.getDeclaredMethod("findDSKey", new CtClass[]{methodCtClass, objectCtClass});
+                findDSKey.setBody("{" +
+                        "   if ($1.getDeclaringClass() == java.lang.Object.class) {" +
+                        "       return \"\";" +
+                        "   }" +
+                        "   java.lang.String ds = computeDatasource($1, $2);" +
+                        "   if (ds == null) {" +
+                        "       return \"\";" +
+                        "   }" +
+                        "   return ds;" +
+                        "}");
+            }
         }
     }
 }


### PR DESCRIPTION
源码中 HikariDataSourceCreator 注入父类中的ioc属性 properties

```java
@Slf4j
@Configuration
@AllArgsConstructor
@EnableConfigurationProperties(DynamicDataSourceProperties.class)
public class DynamicDataSourceCreatorAutoConfiguration {

    private final DynamicDataSourceProperties properties;

    @ConditionalOnClass(HikariDataSource.class)
    @Configuration
    public class HikariDataSourceCreatorConfiguration {
        @Bean
        @Order(HIKARI_ORDER)
        @ConditionalOnMissingBean
        public HikariDataSourceCreator hikariDataSourceCreator() {
            return new HikariDataSourceCreator(properties);
        }
    }
}
```

目前ds中 `@Configuration` 创建的 Cglib 代理类时不会调用任何构造函数(cglib规范)，导致父类中的属性没有值，所以失败。

现在通过拿到 IOC 中创建的 Bean 设置这个值。