### PR TITLE
feat: Add an English semicolon at the end of the sql to facilitate batch execution after copying.

### DIFF
--- a/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/SqlPrintInterceptor.java
+++ b/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/SqlPrintInterceptor.java
@@ -151,6 +151,7 @@ public class SqlPrintInterceptor {
         }
         try {
             String resultSql = dbType.getFormat().format(sta, parameters);
+            resultSql = resultSql.endsWith(";") ? resultSql : resultSql + ";";
 
             if (BooleanUtil.isTrue(MethodTrace.getTraceSqlStatus())) {
                 MethodTrace.enterSql(resultSql);


### PR DESCRIPTION
Before: 
```sql
select * from table1
select * from table2
```
--------------------------
After: 
```sql
select * from table1;
select * from table2;
```