### PR TITLE
perf: 增加日志级别控制

### DIFF
--- a/debug-tools-attach/src/main/java/io/github/future0923/debug/tools/attach/DebugToolsAttach.java
+++ b/debug-tools-attach/src/main/java/io/github/future0923/debug/tools/attach/DebugToolsAttach.java
@@ -54,7 +54,6 @@ public class DebugToolsAttach {
      */
     public static void premain(String agentArgs, Instrumentation inst) throws Exception {
         String javaHome = System.getProperty("java.home");
-        logger.info("JAVA_HOME:{}", javaHome);
         loadToolsJar(javaHome);
         if (ProjectConstants.DEBUG) {
             // 开启javassist debug
@@ -66,6 +65,7 @@ public class DebugToolsAttach {
         if (parse.getLogLevel() != null) {
             Logger.setLevel(parse.getLogLevel());
         }
+        logger.info("JAVA_HOME:{}", javaHome);
         JvmToolsUtils.init();
         SqlPrintByteCodeEnhance.enhance(inst, parse);
         if (Objects.equals(parse.getHotswap(), "true")) {

--- a/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/config/AgentArgs.java
+++ b/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/config/AgentArgs.java
@@ -119,6 +119,9 @@ public class AgentArgs {
                         field.setAccessible(true);
                         if (field.getType() == Integer.class) {
                             field.set(config, Integer.valueOf(keyValue[1]));
+                        } else if (field.getType().isEnum()) {
+                            Class<? extends Enum> enumType = (Class<? extends Enum>) field.getType();
+                            field.set(config, Enum.valueOf(enumType, keyValue[1]));
                         } else {
                             field.set(config, keyValue[1]);
                         }

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/patcher/DebugToolsJavaProgramPatcher.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/patcher/DebugToolsJavaProgramPatcher.java
@@ -130,6 +130,7 @@ public class DebugToolsJavaProgramPatcher extends JavaProgramPatcher {
                 }
             }
             agentArgs.setPrintSql(settingState.getPrintSql().getType());
+            agentArgs.setLogLevel(settingState.getLogLevel());
             agentArgs.setTraceSql(Boolean.toString(traceSql));
             agentArgs.setAutoAttach(settingState.getAutoAttach().toString());
             agentArgs.setAutoSaveSql(settingState.getAutoSaveSql().toString());

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/setting/DebugToolsSettingConfigurable.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/setting/DebugToolsSettingConfigurable.java
@@ -27,6 +27,7 @@ import io.github.future0923.debug.tools.base.enums.PrintSqlType;
 import io.github.future0923.debug.tools.base.hutool.core.util.BooleanUtil;
 import io.github.future0923.debug.tools.base.hutool.core.util.ObjectUtil;
 import io.github.future0923.debug.tools.base.hutool.core.util.StrUtil;
+import io.github.future0923.debug.tools.base.logging.Logger;
 import io.github.future0923.debug.tools.common.dto.TraceMethodDTO;
 import io.github.future0923.debug.tools.idea.bundle.DebugToolsBundle;
 import io.github.future0923.debug.tools.idea.tool.DebugToolsToolWindow;
@@ -166,6 +167,24 @@ public class DebugToolsSettingConfigurable implements Configurable {
         if (BooleanUtil.isFalse(settingState.getInvokeMethodRecord()) && settingPanel.getInvokeMethodRecordYes().isSelected()) {
             return true;
         }
+        if (Logger.Level.ERROR.equals(settingState.getLogLevel()) && !settingPanel.getLogLevelError().isSelected()) {
+            return true;
+        }
+        if (Logger.Level.RELOAD.equals(settingState.getLogLevel()) && !settingPanel.getLogLevelReload().isSelected()) {
+            return true;
+        }
+        if (Logger.Level.WARNING.equals(settingState.getLogLevel()) && !settingPanel.getLogLevelWarning().isSelected()) {
+            return true;
+        }
+        if (Logger.Level.INFO.equals(settingState.getLogLevel()) && !settingPanel.getLogLevelInfo().isSelected()) {
+            return true;
+        }
+        if (Logger.Level.DEBUG.equals(settingState.getLogLevel()) && !settingPanel.getLogLevelDebug().isSelected()) {
+            return true;
+        }
+        if (Logger.Level.TRACE.equals(settingState.getLogLevel()) && !settingPanel.getLogLevelTrace().isSelected()) {
+            return true;
+        }
 
         return false;
     }
@@ -200,6 +219,26 @@ public class DebugToolsSettingConfigurable implements Configurable {
         if (GenParamType.ALL.equals(settingState.getDefaultGenParamType())) {
             settingPanel.getDefaultGenParamTypeAll().setSelected(true);
         }
+
+        if (Logger.Level.ERROR.equals(settingState.getLogLevel())) {
+            settingPanel.getLogLevelError().setSelected(true);
+        }
+        if (Logger.Level.RELOAD.equals(settingState.getLogLevel())) {
+            settingPanel.getLogLevelReload().setSelected(true);
+        }
+        if (Logger.Level.WARNING.equals(settingState.getLogLevel())) {
+            settingPanel.getLogLevelWarning().setSelected(true);
+        }
+        if (Logger.Level.INFO.equals(settingState.getLogLevel())) {
+            settingPanel.getLogLevelInfo().setSelected(true);
+        }
+        if (Logger.Level.DEBUG.equals(settingState.getLogLevel())) {
+            settingPanel.getLogLevelDebug().setSelected(true);
+        }
+        if (Logger.Level.TRACE.equals(settingState.getLogLevel())) {
+            settingPanel.getLogLevelTrace().setSelected(true);
+        }
+
 
         if (PrintSqlType.PRETTY.equals(settingState.getPrintSql()) || PrintSqlType.YES.equals(settingState.getPrintSql())) {
             settingPanel.getPrintPrettySql().setSelected(true);
@@ -277,6 +316,44 @@ public class DebugToolsSettingConfigurable implements Configurable {
         if (settingPanel.getDefaultGenParamTypeAll().isSelected()) {
             settingState.setDefaultGenParamType(GenParamType.ALL);
         }
+
+        if (settingPanel.getLogLevelError().isSelected()) {
+            if (settingState.getLogLevel() != Logger.Level.ERROR) {
+                DebugToolsNotifierUtil.notifyInfo(project, StrUtil.format("Log level changed from {} to {}", settingState.getLogLevel(), "ERROR"));
+            }
+            settingState.setLogLevel(Logger.Level.ERROR);
+        }
+        if (settingPanel.getLogLevelReload().isSelected()) {
+            if (settingState.getLogLevel() != Logger.Level.RELOAD) {
+                DebugToolsNotifierUtil.notifyInfo(project, StrUtil.format("Log level changed from {} to {}", settingState.getLogLevel(), "RELOAD"));
+            }
+            settingState.setLogLevel(Logger.Level.RELOAD);
+        }
+        if (settingPanel.getLogLevelWarning().isSelected()) {
+            if (settingState.getLogLevel() != Logger.Level.WARNING) {
+                DebugToolsNotifierUtil.notifyInfo(project, StrUtil.format("Log level changed from {} to {}", settingState.getLogLevel(), "WARNING"));
+            }
+            settingState.setLogLevel(Logger.Level.WARNING);
+        }
+        if (settingPanel.getLogLevelInfo().isSelected()) {
+            if (settingState.getLogLevel() != Logger.Level.INFO) {
+                DebugToolsNotifierUtil.notifyInfo(project, StrUtil.format("Log level changed from {} to {}", settingState.getLogLevel(), "INFO"));
+            }
+            settingState.setLogLevel(Logger.Level.INFO);
+        }
+        if (settingPanel.getLogLevelDebug().isSelected()) {
+            if (settingState.getLogLevel() != Logger.Level.DEBUG) {
+                DebugToolsNotifierUtil.notifyInfo(project, StrUtil.format("Log level changed from {} to {}", settingState.getLogLevel(), "DEBUG"));
+            }
+            settingState.setLogLevel(Logger.Level.DEBUG);
+        }
+        if (settingPanel.getLogLevelTrace().isSelected()) {
+            if (settingState.getLogLevel() != Logger.Level.TRACE) {
+                DebugToolsNotifierUtil.notifyInfo(project, StrUtil.format("Log level changed from {} to {}", settingState.getLogLevel(), "TRACE"));
+            }
+            settingState.setLogLevel(Logger.Level.TRACE);
+        }
+
 
         settingState.setLineMarkerVisible(settingPanel.getShowLineMarker().isSelected());
 

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/setting/DebugToolsSettingState.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/setting/DebugToolsSettingState.java
@@ -98,6 +98,11 @@ public class DebugToolsSettingState implements PersistentStateComponent<DebugToo
     private Boolean lineMarkerVisible;
 
     /**
+     * 插件日志级别
+     */
+    private io.github.future0923.debug.tools.base.logging.Logger.Level logLevel = io.github.future0923.debug.tools.base.logging.Logger.Level.ERROR;
+
+    /**
      * 本地的http端口
      */
     private Integer localHttpPort;

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/setting/SettingPanel.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/setting/SettingPanel.java
@@ -26,6 +26,7 @@ import com.intellij.ui.components.JBTextArea;
 import com.intellij.util.ui.FormBuilder;
 import io.github.future0923.debug.tools.base.enums.PrintSqlType;
 import io.github.future0923.debug.tools.base.hutool.core.util.BooleanUtil;
+import io.github.future0923.debug.tools.base.logging.Logger;
 import io.github.future0923.debug.tools.idea.bundle.DebugToolsBundle;
 import io.github.future0923.debug.tools.idea.setting.DebugToolsGlobalSettingState;
 import io.github.future0923.debug.tools.idea.setting.DebugToolsSettingState;
@@ -103,6 +104,19 @@ public class SettingPanel {
 
     @Getter
     private final JBRadioButton languageChinese = new JBRadioButton(LanguageSetting.CHINESE.getDisplayName());
+
+    @Getter
+    private final JBRadioButton logLevelError = new JBRadioButton("Error");
+    @Getter
+    private final JBRadioButton logLevelReload = new JBRadioButton("Reload");
+    @Getter
+    private final JBRadioButton logLevelWarning = new JBRadioButton("Warning");
+    @Getter
+    private final JBRadioButton logLevelInfo = new JBRadioButton("Info");
+    @Getter
+    private final JBRadioButton logLevelDebug = new JBRadioButton("Debug");
+    @Getter
+    private final JBRadioButton logLevelTrace = new JBRadioButton("Trace");
 
     public SettingPanel(Project project) {
         this.project = project;
@@ -253,6 +267,39 @@ public class SettingPanel {
             invokeMethodRecordNo.setSelected(true);
         }
 
+        JBRadioButton[] logLevelButtons = {
+                logLevelError,
+                logLevelReload,
+                logLevelWarning,
+                logLevelInfo,
+                logLevelDebug,
+                logLevelTrace
+        };
+
+        JPanel logLevel = new JPanel(new FlowLayout(FlowLayout.LEFT, 5, 5));
+        ButtonGroup logLevelButtonGroup = new ButtonGroup();
+
+        for (JBRadioButton logLevelButton : logLevelButtons) {
+            logLevel.add(logLevelButton);
+            logLevelButtonGroup.add(logLevelButton);
+        }
+
+        Logger.Level[] levels = Logger.Level.values();
+        for (int i = 0; i < levels.length; i++) {
+            if (levels[i] == settingState.getLogLevel()) {
+                logLevelButtons[i].setSelected(true);
+                break;
+            }
+        }
+
+        if (Logger.Level.ERROR.equals(settingState.getLogLevel())) {
+            logLevelError.setSelected(true);
+        } else if (GenParamType.CURRENT.equals(settingState.getDefaultGenParamType())) {
+            defaultGenParamTypeCurrent.setSelected(true);
+        } else if (GenParamType.ALL.equals(settingState.getDefaultGenParamType())) {
+            defaultGenParamTypeAll.setSelected(true);
+        }
+
         removeContextPath.setText(settingState.getRemoveContextPath());
         // 添加边框
         Border border = BorderFactory.createLineBorder(JBColor.GRAY); // 创建灰色线条边框
@@ -304,6 +351,10 @@ public class SettingPanel {
                 .addLabeledComponent(
                         new JBLabel(DebugToolsBundle.message("setting.panel.trace.method")),
                         traceMethodPanel.getComponent()
+                )
+                .addLabeledComponent(
+                        new JBLabel(DebugToolsBundle.message("setting.panel.log.level")),
+                        logLevel
                 )
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();

--- a/debug-tools-idea/src/main/resources/messages/DebugToolsBundle_en.properties
+++ b/debug-tools-idea/src/main/resources/messages/DebugToolsBundle_en.properties
@@ -139,6 +139,7 @@ setting.panel.print.sql=Print sql:
 setting.panel.auto.attach.start.application=Auto attach start application:
 setting.panel.remove.context.path=Remove context path:
 setting.panel.trace.method=Trace method:
+setting.panel.log.level=Log level:
 
 invoke.method.record.restart.message=Changing the call method record configuration requires restarting IntelliJ IDEA to take effect. Do you want to restart now?
 

--- a/debug-tools-idea/src/main/resources/messages/DebugToolsBundle_zh.properties
+++ b/debug-tools-idea/src/main/resources/messages/DebugToolsBundle_zh.properties
@@ -139,6 +139,7 @@ setting.panel.print.sql=\u6253\u5370SQL:
 setting.panel.auto.attach.start.application=\u81EA\u52A8\u9644\u7740\u542F\u52A8\u7684\u5E94\u7528\u7A0B\u5E8F:
 setting.panel.remove.context.path=\u79FB\u9664\u4E0A\u4E0B\u6587\u8DEF\u5F84:
 setting.panel.trace.method=\u8DDF\u8E2A\u65B9\u6CD5:
+setting.panel.log.level=\u65E5\u5FD7\u7EA7\u522B\uFF1A:
 
 invoke.method.record.restart.message=\u66F4\u6539\u8C03\u7528\u65B9\u6CD5\u8BB0\u5F55\u914D\u7F6E\u9700\u8981\u91CD\u542F IntelliJ IDEA \u624D\u80FD\u751F\u6548\uFF0C\u662F\u5426\u73B0\u5728\u91CD\u542F\uFF1F
 


### PR DESCRIPTION
插件默认日志级别为INFO，对于大多场景并无实际意义。增加开关便于异常情况下排查