### PR TITLE
fix(spring): 修复MockMultipartFile转换时缺失文件类型

### DIFF
--- a/debug-tools-extension/debug-tools-extension-spring/src/main/java/io/github/future0923/debug/tools/extension/spring/method/SpringParamConvertUtils.java
+++ b/debug-tools-extension/debug-tools-extension-spring/src/main/java/io/github/future0923/debug/tools/extension/spring/method/SpringParamConvertUtils.java
@@ -142,7 +142,9 @@ public class SpringParamConvertUtils {
                 for (Object item : (Iterable<?>) runContentDTO.getContent()) {
                     File file = new File(item.toString());
                     try {
-                        multipartFiles.add(new MockMultipartFile(file.getName(), FileUtil.getInputStream(file)));
+                        String originalFilename = file.getName();
+                        String contentType = FileUtil.getMimeType(file.getPath());
+                        multipartFiles.add(new MockMultipartFile(originalFilename, originalFilename, contentType, FileUtil.getInputStream(file)));
                     } catch (IOException e) {
                         log.error("转换MockMultipartFile异常", e);
                     }
@@ -159,7 +161,9 @@ public class SpringParamConvertUtils {
             // 处理单个MultipartFile
             if (MultipartFile.class.isAssignableFrom(parameter.getParameterType())) {
                 try {
-                    return new MockMultipartFile(file.getName(), FileUtil.getInputStream(file));
+                    String originalFilename = file.getName();
+                    String contentType = FileUtil.getMimeType(file.getPath());
+                    return new MockMultipartFile(originalFilename, originalFilename, contentType, FileUtil.getInputStream(file));
                 } catch (IOException e) {
                     log.error("转换MockMultipartFile异常", e);
                     return null;

--- a/debug-tools-test/debug-tools-test-simple/src/main/java/io/github/future0923/debug/tools/test/simple/DaemonExample.java
+++ b/debug-tools-test/debug-tools-test-simple/src/main/java/io/github/future0923/debug/tools/test/simple/DaemonExample.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024-2025 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package io.github.future0923.debug.tools.test.simple;
 
 public class DaemonExample {


### PR DESCRIPTION
- 为MockMultipartFile添加原始文件名参数以保持文件名一致
- 根据文件路径获取并设置正确的MIME类型
- 防止转换过程中缺失内容类型导致的问题
- 在异常处理时记录更详细的错误日志