### PR TITLE
fix: 修复m1版本更换jdk后lib未重新创建导致项目无法启动 #191

### DIFF
--- a/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/utils/DebugToolsFileUtils.java
+++ b/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/utils/DebugToolsFileUtils.java
@@ -120,8 +120,8 @@ public class DebugToolsFileUtils {
         String fileName = prefix + (suffix != null ? suffix : "");
         File tmpLibFile = new File(tempDir, fileName);
 
-        // 不存在当前版本的依赖,创建
-        if (!tmpLibFile.exists()) {
+        // 不存在当前版本的依赖或mac更换了jdk版本,创建
+        if ((!tmpLibFile.exists()) || (DebugToolsOSUtils.isMac() && DebugToolsJvmUtils.changeJdk(Boolean.TRUE))) {
             try (FileOutputStream tmpLibOutputStream = new FileOutputStream(tmpLibFile);
                  InputStream inputStreamNew = inputStream) {
                 DebugToolsIOUtils.copy(inputStreamNew, tmpLibOutputStream);

--- a/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/utils/DebugToolsJvmUtils.java
+++ b/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/utils/DebugToolsJvmUtils.java
@@ -16,7 +16,10 @@
  */
 package io.github.future0923.debug.tools.base.utils;
 
+import io.github.future0923.debug.tools.base.config.AgentConfig;
 import io.github.future0923.debug.tools.base.hutool.core.io.FileUtil;
+import io.github.future0923.debug.tools.base.hutool.core.util.StrUtil;
+import io.github.future0923.debug.tools.base.logging.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,6 +31,9 @@ import java.util.jar.JarFile;
  * @author future0923
  */
 public class DebugToolsJvmUtils {
+
+    private static final Logger logger = Logger.getLogger(DebugToolsJvmUtils.class);
+
 
     public static String getMainClass() {
         String javaClassPath = getJavaClassPath();
@@ -68,5 +74,21 @@ public class DebugToolsJvmUtils {
 
     public static String getSunJavaCommand() {
         return ManagementFactory.getRuntimeMXBean().getSystemProperties().get("sun.java.command");
+    }
+
+    public static boolean changeJdk(Boolean ignoreChangeLog) {
+        String storedArch = AgentConfig.INSTANCE.getCurrentOsArch();
+        // 第一次运行
+        if (StrUtil.isBlank(storedArch)) {
+            logger.info("DebugTools first use, current os arch:", DebugToolsOSUtils.arch());
+            return true;
+        }
+
+        boolean changed = !StrUtil.equals(DebugToolsOSUtils.arch(), storedArch);
+
+        if (changed && !ignoreChangeLog) {
+            logger.info("Jvm os arch has changed,current os arch: {},stored os arch: {}", DebugToolsOSUtils.arch(), storedArch);
+        }
+        return changed;
     }
 }

--- a/debug-tools-vm/src/main/java/io/github/future0923/debug/tools/vm/JvmToolsUtils.java
+++ b/debug-tools-vm/src/main/java/io/github/future0923/debug/tools/vm/JvmToolsUtils.java
@@ -18,9 +18,8 @@ package io.github.future0923.debug.tools.vm;
 
 import io.github.future0923.debug.tools.base.config.AgentConfig;
 import io.github.future0923.debug.tools.base.constants.ProjectConstants;
-import io.github.future0923.debug.tools.base.hutool.core.util.StrUtil;
-import io.github.future0923.debug.tools.base.logging.Logger;
 import io.github.future0923.debug.tools.base.utils.DebugToolsFileUtils;
+import io.github.future0923.debug.tools.base.utils.DebugToolsJvmUtils;
 import io.github.future0923.debug.tools.base.utils.DebugToolsOSUtils;
 import io.github.future0923.debug.tools.base.utils.DebugToolsStringUtils;
 
@@ -39,17 +38,15 @@ public class JvmToolsUtils {
 
     private static boolean load = false;
 
-    private static final Logger logger = Logger.getLogger(JvmToolsUtils.class);
-
     public static synchronized void init() {
         if (init) {
             return;
         }
 
         // 目前只针对mac特殊处理
-        if (DebugToolsOSUtils.isMac() && changeJdk()) {
-            AgentConfig.INSTANCE.setCurrentOsArch(DebugToolsOSUtils.arch());
+        if (DebugToolsOSUtils.isMac() && DebugToolsJvmUtils.changeJdk(Boolean.FALSE)) {
             storeLib(getLibName());
+            AgentConfig.INSTANCE.setCurrentOsArchAndStore(DebugToolsOSUtils.arch());
             return;
         }
 
@@ -106,19 +103,4 @@ public class JvmToolsUtils {
         AgentConfig.INSTANCE.setJniLibraryPathAndStore(jniLibraryFile.getAbsolutePath());
     }
 
-    private static boolean changeJdk() {
-        String storedArch = AgentConfig.INSTANCE.getCurrentOsArch();
-        // 第一次运行
-        if (StrUtil.isBlank(storedArch)) {
-            logger.info("DebugTools first use, current os arch:", DebugToolsOSUtils.arch());
-            return true;
-        }
-
-        boolean changed = !StrUtil.equals(DebugToolsOSUtils.arch(), storedArch);
-
-        if (changed) {
-            logger.info("Jvm os arch has changed,current os arch: {},stored os arch: {}", DebugToolsOSUtils.arch(), storedArch);
-        }
-        return changed;
-    }
 }


### PR DESCRIPTION
现象：项目用的jdk由8更换为17后，项目无法启动。报错参考issue #197
原因：当前插件版本不存在时才会创建lib，而mac的arm版本jdk8是在x86_64的情况下创建的，如果更换了jdk版本不重新创建就会报错
解决方案：当插件版本不存在或mac更换了jdk后重新创建