### PR TITLE
feat(enum): 支持数组和泛型集合类型的枚举参数转换  closes #205

### DIFF
--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/utils/DebugToolsJsonElementUtil.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/utils/DebugToolsJsonElementUtil.java
@@ -133,6 +133,18 @@ public class DebugToolsJsonElementUtil {
                             return RunContentType.FILE.getType();
                         } else if (aClass.isAssignableFrom(Class.class)) {
                             return RunContentType.CLASS.getType();
+                        } else if (isCollType(aClass)) {
+                            // 检查集合的泛型参数是否为枚举类型
+                            PsiType[] parameters = ((PsiClassType) type).getParameters();
+                            if (parameters.length > 0) {
+                                PsiType genericType = parameters[0];
+                                if (genericType instanceof PsiClassType) {
+                                    PsiClass genericClass = ((PsiClassType) genericType).resolve();
+                                    if (genericClass != null && genericClass.isEnum()) {
+                                        return RunContentType.ENUM.getType();
+                                    }
+                                }
+                            }
                         }
                     } catch (Exception ignored) {
                     }

--- a/debug-tools-test/debug-tools-test-spring-boot-mybatis-plus/src/main/java/io/github/future0923/debug/tools/test/spring/boot/mybatisplus/enums/PaymentStatusEnum.java
+++ b/debug-tools-test/debug-tools-test-spring-boot-mybatis-plus/src/main/java/io/github/future0923/debug/tools/test/spring/boot/mybatisplus/enums/PaymentStatusEnum.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2024-2025 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.github.future0923.debug.tools.test.spring.boot.mybatisplus.enums;
+
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @FileName PaymentStatusEnum
+ * @Description
+ * @Author 22161
+ * @date 2026-01-13
+ **/
+public enum PaymentStatusEnum {
+    UNPAID(1, "未支付"),
+    PAYING(2, "支付中"),
+    PAID(3, "已支付"),
+    FAILED(4, "支付失败"),
+    REFUNDING(5, "退款中"),
+    REFUNDED(6, "已退款"),
+    CLOSED(7, "已关闭");
+
+    private final Integer value;
+    private final String desc;
+
+    // 可支付的状态集合
+    private static final List<Integer> CAN_PAY_STATUS_SET = List.of(
+            UNPAID.getValue(),
+            FAILED.getValue()
+    );
+
+    // 可退款的状态集合
+    private static final List<Integer> CAN_REFUND_STATUS_SET = List.of(
+            PAID.getValue()
+    );
+
+    // 可关闭的状态列表
+    public static final List<PaymentStatusEnum> CAN_CLOSE_STATUS_LIST = Arrays.asList(
+            UNPAID,
+            FAILED
+    );
+
+    // 可重试的状态列表
+    public static final List<PaymentStatusEnum> CAN_RETRY_STATUS_LIST = Arrays.asList(
+            FAILED
+    );
+
+    /**
+     * 判断状态是否可支付
+     */
+    public static boolean canPay(Integer status) {
+        return CAN_PAY_STATUS_SET.contains(status);
+    }
+
+    /**
+     * 判断状态是否可退款
+     */
+    public static boolean canRefund(Integer status) {
+        return CAN_REFUND_STATUS_SET.contains(status);
+    }
+
+    /**
+     * 判断状态是否可关闭
+     */
+    public static boolean canClose(Integer status) {
+        return CAN_CLOSE_STATUS_LIST.stream()
+                .map(PaymentStatusEnum::getValue)
+                .anyMatch(value -> value.equals(status));
+    }
+
+    /**
+     * 判断状态是否可重试支付
+     */
+    public static boolean canRetry(Integer status) {
+        return CAN_RETRY_STATUS_LIST.stream()
+                .map(PaymentStatusEnum::getValue)
+                .anyMatch(value -> value.equals(status));
+    }
+
+    /**
+     * 根据值获取枚举
+     */
+    public static PaymentStatusEnum getByValue(Integer value) {
+        if (value == null) {
+            return null;
+        }
+        return Arrays.stream(values())
+                .filter(e -> e.getValue().equals(value))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * 根据值获取描述
+     */
+    public static String getDescByValue(Integer value) {
+        return Optional.ofNullable(getByValue(value))
+                .map(PaymentStatusEnum::getDesc)
+                .orElse(null);
+    }
+
+    /**
+     * 获取所有支付成功相关的状态
+     */
+    public static Set<Integer> getSuccessRelatedStatusValues() {
+        return Arrays.stream(values())
+                .filter(e -> e == PAID || e == REFUNDED)
+                .map(PaymentStatusEnum::getValue)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * 获取所有可操作的状态（支付失败后可重试等）
+     */
+    public static Set<Integer> getOperableStatusValues() {
+        return Arrays.stream(values())
+                .filter(e -> canRetry(e.getValue()) || canRefund(e.getValue()))
+                .map(PaymentStatusEnum::getValue)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * 判断当前枚举值是否等于指定值
+     */
+    public boolean eq(Integer value) {
+        return this.value.equals(value);
+    }
+
+    /**
+     * 判断是否为终态（不再变化的状态）
+     */
+    public static boolean isFinalStatus(Integer status) {
+        return Arrays.asList(REFUNDED.getValue(), CLOSED.getValue())
+                .contains(status);
+    }
+
+    public Integer getValue() {
+        return this.value;
+    }
+
+    public String getDesc() {
+        return this.desc;
+    }
+
+    private PaymentStatusEnum(final Integer value, final String desc) {
+        this.value = value;
+        this.desc = desc;
+    }
+}

--- a/debug-tools-test/debug-tools-test-spring-boot-mybatis-plus/src/main/java/io/github/future0923/debug/tools/test/spring/boot/mybatisplus/enums/TaskStatusEnum.java
+++ b/debug-tools-test/debug-tools-test-spring-boot-mybatis-plus/src/main/java/io/github/future0923/debug/tools/test/spring/boot/mybatisplus/enums/TaskStatusEnum.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2024-2025 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.github.future0923.debug.tools.test.spring.boot.mybatisplus.enums;
+
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @FileName TaskStatusEnum
+ * @Description
+ * @Author 22161
+ * @date 2026-01-13
+ **/
+public enum TaskStatusEnum {
+    PENDING(1, "待处理"),
+    PROCESSING(2, "处理中"),
+    REVIEWING(3, "审核中"),
+    COMPLETED(4, "已完成"),
+    REJECTED(5, "已拒绝"),
+    CANCELLED(6, "已取消");
+
+    private final Integer value;
+    private final String desc;
+
+    // 可重新分配的状态集合
+    private static final List<Integer> CAN_REASSIGN_STATUS_SET = List.of(
+            PENDING.getValue(),
+            REJECTED.getValue()
+    );
+
+    // 可修改的状态集合
+    private static final List<Integer> CAN_MODIFY_STATUS_SET = List.of(
+            PENDING.getValue(),
+            PROCESSING.getValue()
+    );
+
+    // 可完成的状态列表
+    public static final List<TaskStatusEnum> CAN_COMPLETE_STATUS_LIST = Arrays.asList(
+            PROCESSING,
+            REVIEWING
+    );
+
+    // 可取消的状态列表
+    public static final List<TaskStatusEnum> CAN_CANCEL_STATUS_LIST = Arrays.asList(
+            PENDING,
+            PROCESSING
+    );
+    public static final List<PaymentStatusEnum> PAYMENT_RELATED_STATUS_LIST = Arrays.asList(
+            PaymentStatusEnum.UNPAID,    // 等待支付
+            PaymentStatusEnum.PAID,        // 已支付
+            PaymentStatusEnum.REFUNDING    // 退款中
+    );
+    public static final List<PaymentStatusEnum> COMPLETABLE_PAYMENT_STATUS_LIST = Arrays.asList(
+            PaymentStatusEnum.PAID,        // 已支付
+            PaymentStatusEnum.REFUNDED     // 已退款
+    );
+    /**
+     * 判断状态是否可重新分配
+     */
+    public static boolean canReassign(Integer status) {
+        return CAN_REASSIGN_STATUS_SET.contains(status);
+    }
+    public static boolean isPaymentRelated(Integer paymentStatus) {
+        if (paymentStatus == null) {
+            return false;
+        }
+        return PAYMENT_RELATED_STATUS_LIST.stream()
+                .map(PaymentStatusEnum::getValue)
+                .anyMatch(value -> value.equals(paymentStatus));
+    }
+    public static boolean isPaymentCompletable(Integer paymentStatus) {
+        if (paymentStatus == null) {
+            return false;
+        }
+        return COMPLETABLE_PAYMENT_STATUS_LIST.stream()
+                .map(PaymentStatusEnum::getValue)
+                .anyMatch(value -> value.equals(paymentStatus));
+    }
+    /**
+     * 判断状态是否可修改
+     */
+    public static boolean canModify(Integer status) {
+        return CAN_MODIFY_STATUS_SET.contains(status);
+    }
+
+    /**
+     * 判断状态是否可完成
+     */
+    public static boolean canComplete(Integer status) {
+        return CAN_COMPLETE_STATUS_LIST.stream()
+                .map(TaskStatusEnum::getValue)
+                .anyMatch(value -> value.equals(status));
+    }
+
+    /**
+     * 判断状态是否可取消
+     */
+    public static boolean canCancel(Integer status) {
+        return CAN_CANCEL_STATUS_LIST.stream()
+                .map(TaskStatusEnum::getValue)
+                .anyMatch(value -> value.equals(status));
+    }
+
+    /**
+     * 根据值获取枚举
+     */
+    public static TaskStatusEnum getByValue(Integer value) {
+        if (value == null) {
+            return null;
+        }
+        return Arrays.stream(values())
+                .filter(e -> e.getValue().equals(value))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * 根据值获取描述
+     */
+    public static String getDescByValue(Integer value) {
+        return Optional.ofNullable(getByValue(value))
+                .map(TaskStatusEnum::getDesc)
+                .orElse(null);
+    }
+
+    /**
+     * 判断当前枚举值是否等于指定值
+     */
+    public boolean eq(Integer value) {
+        return this.value.equals(value);
+    }
+
+    /**
+     * 获取所有可修改状态的值
+     */
+    public static Set<Integer> getModifiableStatusValues() {
+        return CAN_MODIFY_STATUS_SET.stream()
+                .collect(Collectors.toSet());
+    }
+
+    public Integer getValue() {
+        return this.value;
+    }
+
+    public String getDesc() {
+        return this.desc;
+    }
+
+    private TaskStatusEnum(final Integer value, final String desc) {
+        this.value = value;
+        this.desc = desc;
+    }
+}

--- a/debug-tools-test/debug-tools-test-spring-boot-mybatis-plus/src/main/java/io/github/future0923/debug/tools/test/spring/boot/mybatisplus/service/EnumServiceImpl.java
+++ b/debug-tools-test/debug-tools-test-spring-boot-mybatis-plus/src/main/java/io/github/future0923/debug/tools/test/spring/boot/mybatisplus/service/EnumServiceImpl.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024-2025 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.github.future0923.debug.tools.test.spring.boot.mybatisplus.service;
+
+
+import io.github.future0923.debug.tools.test.spring.boot.mybatisplus.enums.TaskStatusEnum;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+import java.util.List;
+
+/**
+ * @FileName EnumServiceImpl
+ * @Description
+ * @Author 22161
+ * @date 2026-01-13
+ **/
+@Service
+public class EnumServiceImpl {
+    @Resource private UserServiceImpl userService;
+    public void test(Long id, List<TaskStatusEnum> enumTest, String name) {
+        System.out.println("test");
+    }
+}


### PR DESCRIPTION
- 在Spring扩展模块中为枚举类型参数添加数组和泛型集合支持
- 在IDEA插件中增强类型检测，识别泛型集合中的枚举类型
- 在服务器模块中统一处理数组和List<Enum>类型的参数转换
- 使用ResolvableType解析泛型参数类型确保类型安全