### PR TITLE
feat(spring): 增强Spring Bean管理功能 close #206

### DIFF
--- a/debug-tools-server/src/main/java/io/github/future0923/debug/tools/server/utils/DebugToolsEnvUtils.java
+++ b/debug-tools-server/src/main/java/io/github/future0923/debug/tools/server/utils/DebugToolsEnvUtils.java
@@ -24,6 +24,7 @@ import io.github.future0923.debug.tools.base.utils.DebugToolsClassUtils;
 import io.github.future0923.debug.tools.common.dto.RunContentDTO;
 import io.github.future0923.debug.tools.common.dto.RunDTO;
 import io.github.future0923.debug.tools.server.http.handler.AllClassLoaderHttpHandler;
+import org.springframework.beans.factory.config.BeanDefinition;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -43,7 +44,7 @@ public class DebugToolsEnvUtils {
     private static final Logger logger = Logger.getLogger(DebugToolsEnvUtils.class);
 
     private static final Map<ClassLoader, DebugToolsExtensionClassLoader> EXTENSION_CLASS_LOADER_MAP = new HashMap<>();
-    
+
     private static ClassLoader appClassLoader;
 
     private static DebugToolsExtensionClassLoader getExtensionClassLoader(ClassLoader classLoader) {
@@ -125,6 +126,14 @@ public class DebugToolsEnvUtils {
         }
     }
 
+    /**
+     * 根据Bean名称获取最后一个Bean实例
+     *
+     * @param beanName Bean名称
+     * @param <T> Bean类型
+     * @return Bean实例，如果Spring环境工具类不存在则返回null
+     * @throws Exception 反射调用异常
+     */
     @SuppressWarnings("unchecked")
     public static <T> T getLastBean(String beanName) throws Exception {
         Class<?> springEnvUtil = getSpringEnvUtilClass();
@@ -136,6 +145,15 @@ public class DebugToolsEnvUtils {
         return (T) getLastBean.invoke(null, beanName);
     }
 
+
+    /**
+     * 根据Bean名称获取Bean实例列表
+     *
+     * @param beanName Bean名称
+     * @param <T> Bean类型
+     * @return Bean实例列表，如果Spring环境工具类不存在则返回null
+     * @throws Exception 反射调用异常
+     */
     @SuppressWarnings("unchecked")
     public static <T> List<T> getBeans(String beanName) throws Exception {
         Class<?> springEnvUtil = getSpringEnvUtilClass();
@@ -147,6 +165,47 @@ public class DebugToolsEnvUtils {
         return (List<T>) getBeans.invoke(null, beanName);
     }
 
+    /**
+     * 根据类型获取Bean名称数组
+     *
+     * @param type Bean类型
+     * @return Bean名称数组，如果Spring环境工具类不存在则返回null
+     * @throws Exception 反射调用异常
+     */
+    public static String[] getBeanNamesForType(Class<?> type) throws Exception {
+        Class<?> springEnvUtil = getSpringEnvUtilClass();
+        if (springEnvUtil == null) {
+            return null;
+        }
+        DebugToolsClassUtils.loadDebugToolsClass(appClassLoader, "org.springframework.beans.factory.BeanFactory");
+        Method getBeanNamesForType = springEnvUtil.getMethod("getBeanNamesForType", Class.class);
+        return (String[]) getBeanNamesForType.invoke(null, type);
+    }
+
+    /**
+     * 根据Bean名称获取Bean定义
+     *
+     * @param beanName Bean名称
+     * @return Bean定义对象，如果Spring环境工具类不存在则返回null
+     * @throws Exception 反射调用异常
+     */
+    public static BeanDefinition getBeanDefinition(String beanName) throws Exception {
+        Class<?> springEnvUtil = getSpringEnvUtilClass();
+        if (springEnvUtil == null) {
+            return null;
+        }
+        DebugToolsClassUtils.loadDebugToolsClass(appClassLoader, "org.springframework.beans.factory.BeanFactory");
+        Method getBeanDefinition = springEnvUtil.getMethod("getBeanDefinition", String.class);
+        return (BeanDefinition) getBeanDefinition.invoke(null, beanName);
+    }
+
+    /**
+     * 根据类型获取Bean实例
+     *
+     * @param requiredType Bean类型
+     * @return Bean实例，如果Spring环境工具类不存在则返回null
+     * @throws Exception 反射调用异常
+     */
     public static <T> T getLastBean(Class<T> requiredType) throws Exception {
         try {
             T springLastBean = getSpringLastBean(requiredType);
@@ -158,8 +217,16 @@ public class DebugToolsEnvUtils {
         return getSolonLastBean(requiredType);
     }
 
+    /**
+     * 根据类型获取Spring容器中的最后一个Bean实例
+     *
+     * @param requiredType Bean类型
+     * @param <T> Bean类型
+     * @return Bean实例，如果Spring环境工具类不存在则返回null
+     * @throws Exception 反射调用异常
+     */
     @SuppressWarnings("unchecked")
-    private static  <T> T getSpringLastBean(Class<T> requiredType) throws Exception {
+    private static <T> T getSpringLastBean(Class<T> requiredType) throws Exception {
         Class<?> springEnvUtil = getSpringEnvUtilClass();
         if (springEnvUtil == null) {
             return null;
@@ -169,8 +236,16 @@ public class DebugToolsEnvUtils {
         return (T) getLastBean.invoke(null, requiredType);
     }
 
+    /**
+     * 根据类型获取Solon容器中的最后一个Bean实例
+     *
+     * @param requiredType Bean类型
+     * @param <T> Bean类型
+     * @return Bean实例，如果Solon环境工具类不存在则返回null
+     * @throws Exception 反射调用异常
+     */
     @SuppressWarnings("unchecked")
-    private static  <T> T getSolonLastBean(Class<T> requiredType) throws Exception {
+    private static <T> T getSolonLastBean(Class<T> requiredType) throws Exception {
         Class<?> solonEnvUtil = getSolonEnvUtilClass();
         if (solonEnvUtil == null) {
             return null;
@@ -180,6 +255,14 @@ public class DebugToolsEnvUtils {
         return (T) getLastBean.invoke(null, requiredType);
     }
 
+    /**
+     * 根据类型获取Bean实例列表
+     *
+     * @param requiredType Bean类型
+     * @param <T> Bean类型
+     * @return Bean实例列表，如果Spring环境工具类不存在则返回null
+     * @throws Exception 反射调用异常
+     */
     @SuppressWarnings("unchecked")
     public static <T> List<T> getBeans(Class<T> requiredType) throws Exception {
         Class<?> springEnvUtil = getSpringEnvUtilClass();
@@ -191,6 +274,12 @@ public class DebugToolsEnvUtils {
         return (List<T>) getBean.invoke(null, requiredType);
     }
 
+    /**
+     * 注册Bean到Spring容器
+     *
+     * @param bean Bean实例
+     * @throws Exception 反射调用异常
+     */
     public static <T> void registerBean(T bean) throws Exception {
         Class<?> springEnvUtil = getSpringEnvUtilClass();
         if (springEnvUtil == null) {
@@ -201,6 +290,13 @@ public class DebugToolsEnvUtils {
         registerBean.invoke(null, bean);
     }
 
+    /**
+     * 注册Bean到Spring容器
+     *
+     * @param beanName Bean名称
+     * @param bean Bean实例
+     * @throws Exception 反射调用异常
+     */
     public static <T> void registerBean(String beanName, T bean) throws Exception {
         Class<?> springEnvUtil = getSpringEnvUtilClass();
         if (springEnvUtil == null) {
@@ -211,6 +307,29 @@ public class DebugToolsEnvUtils {
         registerBean.invoke(null, beanName, bean);
     }
 
+    /**
+     * 注册Bean到Spring容器
+     *
+     * @param beanName Bean名称
+     * @param beanClass Bean类
+     * @throws Exception 反射调用异常
+     */
+    public static <T> void registerBean(String beanName,Class<T> beanClass) throws Exception {
+        Class<?> springEnvUtil = getSpringEnvUtilClass();
+        if (springEnvUtil == null) {
+            return;
+        }
+        DebugToolsClassUtils.loadDebugToolsClass(appClassLoader, "org.springframework.beans.factory.BeanFactory");
+        Method registerBean = springEnvUtil.getMethod("registerBean", String.class, Class.class);
+        registerBean.invoke(null, beanName, beanClass);
+    }
+
+    /**
+     * 从Spring容器中注销指定名称的Bean
+     *
+     * @param beanName 要注销的Bean名称
+     * @throws Exception 反射调用异常
+     */
     public static void unregisterBean(String beanName) throws Exception {
         Class<?> springEnvUtil = getSpringEnvUtilClass();
         if (springEnvUtil == null) {
@@ -221,6 +340,29 @@ public class DebugToolsEnvUtils {
         unregisterBean.invoke(null, beanName);
     }
 
+    /**
+     * 从Spring容器中注销指定名称的Bean以及Bean的定义
+     *
+     * @param beanName 要注销的Bean名称
+     * @throws Exception 反射调用异常
+     */
+    public static void unregisterBeanAndDefinition(String beanName) throws Exception {
+        Class<?> springEnvUtil = getSpringEnvUtilClass();
+        if (springEnvUtil == null) {
+            return;
+        }
+        DebugToolsClassUtils.loadDebugToolsClass(appClassLoader, "org.springframework.beans.factory.BeanFactory");
+        Method unregisterBeanAndDefinition = springEnvUtil.getMethod("unregisterBeanAndDefinition", String.class);
+        unregisterBeanAndDefinition.invoke(null, beanName);
+    }
+
+    /**
+     * 获取Spring配置属性的值
+     *
+     * @param value 配置键
+     * @return 配置值，如果Spring环境工具类不存在则返回null
+     * @throws Exception 反射调用异常
+     */
     public static Object getSpringConfig(String value) throws Exception {
         Class<?> springEnvUtil = getSpringEnvUtilClass();
         if (springEnvUtil == null) {
@@ -231,6 +373,13 @@ public class DebugToolsEnvUtils {
         return getSpringConfig.invoke(null, value);
     }
 
+    /**
+     * 获取AOP代理对象的原始目标对象
+     *
+     * @param candidate 可能是代理对象
+     * @param <T> 目标对象类型
+     * @return 原始目标对象，如果不是代理对象则返回自身
+     */
     @SuppressWarnings("unchecked")
     public static <T> T getTargetObject(Object candidate) {
         Class<?> springEnvUtil = getSpringEnvUtilClass();
@@ -246,6 +395,12 @@ public class DebugToolsEnvUtils {
         }
     }
 
+    /**
+     * 获取AOP代理对象的原始目标类
+     *
+     * @param candidate 可能是代理对象
+     * @return 原始目标类，如果不是代理对象则返回自身的类
+     */
     public static Class<?> getTargetClass(Object candidate) {
         Class<?> springEnvUtil = getSpringEnvUtilClass();
         if (springEnvUtil == null) {
@@ -260,6 +415,12 @@ public class DebugToolsEnvUtils {
         }
     }
 
+    /**
+     * 查找桥接方法对应的原始方法
+     *
+     * @param targetMethod 可能是桥接方法
+     * @return 原始方法，如果不是桥接方法则返回自身
+     */
     public static Method findBridgedMethod(Method targetMethod) {
         Class<?> springEnvUtil = getSpringEnvUtilClass();
         if (springEnvUtil == null) {
@@ -276,6 +437,11 @@ public class DebugToolsEnvUtils {
         }
     }
 
+    /**
+     * 设置当前线程的HTTP请求对象
+     *
+     * @param runDTO 包含请求信息的DTO对象
+     */
     public static void setRequest(RunDTO runDTO) {
         Class<?> springServletUtil = getSpringServletUtil();
         if (springServletUtil == null) {
@@ -292,6 +458,12 @@ public class DebugToolsEnvUtils {
         }
     }
 
+    /**
+     * 判断调用处理器是否为Spring AOP代理
+     *
+     * @param invocationHandler 调用处理器
+     * @return 如果是Spring AOP代理返回true，否则返回false
+     */
     public static boolean isAopProxy(InvocationHandler invocationHandler) {
         Class<?> springEnvUtil = getSpringEnvUtilClass();
         if (springEnvUtil == null) {
@@ -299,8 +471,8 @@ public class DebugToolsEnvUtils {
         }
         try {
             DebugToolsClassUtils.loadDebugToolsClass(appClassLoader, "org.springframework.aop.framework.AopProxy");
-            Method setRequest = springEnvUtil.getMethod("isAopProxy", InvocationHandler.class);
-            return (boolean) setRequest.invoke(null, invocationHandler);
+            Method isAopProxy = springEnvUtil.getMethod("isAopProxy", InvocationHandler.class);
+            return (boolean) isAopProxy.invoke(null, invocationHandler);
         } catch (InvocationTargetException | IllegalAccessException e) {
             throw new RuntimeException(e);
         } catch (Exception ignored) {
@@ -308,6 +480,13 @@ public class DebugToolsEnvUtils {
         }
     }
 
+    /**
+     * 根据方法参数信息和运行内容生成参数数组
+     *
+     * @param bridgedMethod 桥接方法或原始方法
+     * @param targetMethodContent 方法参数运行内容映射
+     * @return 参数数组
+     */
     public static Object[] getArgs(Method bridgedMethod, Map<String, RunContentDTO> targetMethodContent) {
         Class<?> springEnvUtil = getSpringEnvUtilClass();
         if (springEnvUtil == null) {
@@ -324,6 +503,11 @@ public class DebugToolsEnvUtils {
         }
     }
 
+    /**
+     * 获取当前线程的HTTP请求对象
+     *
+     * @return HTTP请求对象，如果Spring Servlet工具类不存在则返回null
+     */
     public static Object getRequest() {
         Class<?> springServletUtil = getSpringServletUtil();
         if (springServletUtil == null) {
@@ -341,6 +525,11 @@ public class DebugToolsEnvUtils {
         }
     }
 
+    /**
+     * 获取当前线程的响应式HTTP请求对象
+     *
+     * @return ServerHttpRequest对象，如果Spring Reactive工具类不存在则返回null
+     */
     public static Object getServerHttpRequest() {
         Class<?> springReactiveUtil = getSpringReactiveUtil();
         if (springReactiveUtil == null) {
@@ -357,6 +546,11 @@ public class DebugToolsEnvUtils {
         }
     }
 
+    /**
+     * 获取当前线程的ServerWebExchange对象
+     *
+     * @return ServerWebExchange对象，如果Spring Reactive工具类不存在则返回null
+     */
     public static Object getServerWebExchange() {
         Class<?> springReactiveUtil = getSpringReactiveUtil();
         if (springReactiveUtil == null) {
@@ -373,6 +567,11 @@ public class DebugToolsEnvUtils {
         }
     }
 
+    /**
+     * 获取当前线程的HTTP响应对象
+     *
+     * @return HTTP响应对象，如果Spring Servlet工具类不存在则返回null
+     */
     public static Object getResponse() {
         Class<?> springServletUtil = getSpringServletUtil();
         if (springServletUtil == null) {
@@ -380,8 +579,8 @@ public class DebugToolsEnvUtils {
         }
         try {
             DebugToolsClassUtils.loadDebugToolsClass(appClassLoader, "org.springframework.http.MediaType");
-            Method getRequest = springServletUtil.getMethod("getResponse");
-            return getRequest.invoke(null);
+            Method getResponse = springServletUtil.getMethod("getResponse");
+            return getResponse.invoke(null);
         } catch (InvocationTargetException | IllegalAccessException e) {
             throw new RuntimeException(e);
         } catch (Exception ignored) {
@@ -389,6 +588,11 @@ public class DebugToolsEnvUtils {
         }
     }
 
+    /**
+     * 获取当前线程的响应式HTTP响应对象
+     *
+     * @return ServerHttpResponse对象，如果Spring Reactive工具类不存在则返回null
+     */
     public static Object getServerHttpResponse() {
         Class<?> springReactiveUtil = getSpringReactiveUtil();
         if (springReactiveUtil == null) {
@@ -396,8 +600,8 @@ public class DebugToolsEnvUtils {
         }
         try {
             DebugToolsClassUtils.loadDebugToolsClass(appClassLoader, "org.springframework.http.server.reactive.ServerHttpResponse");
-            Method getRequest = springReactiveUtil.getMethod("getServerHttpResponse");
-            return getRequest.invoke(null);
+            Method getServerHttpResponse = springReactiveUtil.getMethod("getServerHttpResponse");
+            return getServerHttpResponse.invoke(null);
         } catch (InvocationTargetException | IllegalAccessException e) {
             throw new RuntimeException(e);
         } catch (Exception ignored) {
@@ -405,6 +609,11 @@ public class DebugToolsEnvUtils {
         }
     }
 
+    /**
+     * 设置XXL-Job任务参数
+     *
+     * @param jobParam 任务参数
+     */
     public static void setXxlJobParam(String jobParam) {
         Class<?> xxlJobEnvUtil = getXxlJobEnvUtil();
         if (xxlJobEnvUtil == null) {


### PR DESCRIPTION
- 新增registerBean方法支持通过类名动态注册Bean定义
- 新增unregisterBeanAndDefinition方法支持同时销毁Bean实例和定义
- 新增getBeanNamesForType和getBeanDefinition方法用于Bean信息查询
- 在Groovy脚本中新增对应的便捷方法（gtbn、gtbd、rb、urbd等）
- 优化unregisterBean方法，增加单例存在性检查和日志输出
- 重构导入语句，使用通配符简化导入
- 为DebugToolsEnvUtils工具类添加完整的方法注释说明