### PR TITLE
issue-248: XDG dirs and agent path fixes

### DIFF
--- a/debug-tools-attach/pom.xml
+++ b/debug-tools-attach/pom.xml
@@ -213,7 +213,7 @@
                         </goals>
                         <configuration>
                             <target>
-                                <delete dir="/Users/weilai/Documents/debug-tools-idea/src/main/resources/lib"/>
+                                <delete dir="${project.basedir}/../debug-tools-idea/src/main/resources/lib"/>
                                 <delete dir="${project.basedir}/../debug-tools-boot/src/main/resources/lib"/>
                                 <delete file="${project.basedir}/../dist/debug-tools-agent.jar"/>
                             </target>
@@ -227,9 +227,9 @@
                         </goals>
                         <configuration>
                             <target>
-                                <mkdir dir="/Users/weilai/Documents/debug-tools-idea/src/main/resources/lib"/>
+                                <mkdir dir="${project.basedir}/../debug-tools-idea/src/main/resources/lib"/>
                                 <copy file="${project.build.directory}/${build.finalName}.jar"
-                                      tofile="/Users/weilai/Documents/debug-tools-idea/src/main/resources/lib/${build.finalName}-${project.version}.jar"
+                                      tofile="${project.basedir}/../debug-tools-idea/src/main/resources/lib/${build.finalName}-${project.version}.jar"
                                       overwrite="true"/>
 
                                 <mkdir dir="${project.basedir}/../debug-tools-boot/src/main/resources/lib"/>

--- a/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/config/AgentConfig.java
+++ b/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/config/AgentConfig.java
@@ -21,6 +21,7 @@ import io.github.future0923.debug.tools.base.constants.ProjectConstants;
 import io.github.future0923.debug.tools.base.logging.Logger;
 import io.github.future0923.debug.tools.base.utils.DebugToolsFileUtils;
 import io.github.future0923.debug.tools.base.utils.DebugToolsLibUtils;
+import io.github.future0923.debug.tools.base.utils.DebugToolsPathUtils;
 import io.github.future0923.debug.tools.base.utils.DebugToolsStringUtils;
 
 import java.io.File;
@@ -62,8 +63,8 @@ public class AgentConfig {
     private boolean isUpgrade;
 
     private AgentConfig() {
-        String homeDir = System.getProperty("user.home");
-        propertiesFile = new File(homeDir + File.separator + ProjectConstants.NAME + File.separator + FILE_NAME);
+        File cacheDir = DebugToolsPathUtils.getCacheDir();
+        propertiesFile = new File(cacheDir, FILE_NAME);
         if (!propertiesFile.exists()) {
             DebugToolsFileUtils.touch(propertiesFile);
         }
@@ -314,3 +315,4 @@ public class AgentConfig {
         return isExtensionJar || isAgentJar || isJniLib;
     }
 }
+

--- a/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/constants/ProjectConstants.java
+++ b/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/constants/ProjectConstants.java
@@ -35,7 +35,7 @@ public interface ProjectConstants {
 
     String CONFIG_FILE = "debug-tools.properties";
 
-    String AUTO_ATTACH_FLAG_FILE = NAME + "/auto_attach.txt";
+    String AUTO_ATTACH_FLAG_FILE = "auto_attach.txt";
 
     String PROJECT_PACKAGE_PREFIX = "io.github.future0923.debug.tools";
 

--- a/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/utils/DebugToolsFileUtils.java
+++ b/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/utils/DebugToolsFileUtils.java
@@ -134,7 +134,7 @@ public class DebugToolsFileUtils {
     private static File createTempDir() {
         File tempDir = DebugToolsLibUtils.getDebugToolsLibDir();
         if (!tempDir.exists()) {
-            if (!tempDir.mkdir()) {
+            if (!mkdirsSafely(tempDir, 5, 1)) {
                 throw new IllegalStateException("Failed to create directory within " + tempDir);
             }
         }
@@ -528,7 +528,10 @@ public class DebugToolsFileUtils {
      * 获取自动附加文件
      */
     public static File getAutoAttachFile() {
-        return FileUtil.touch(FileUtil.getUserHomePath() + "/" + ProjectConstants.AUTO_ATTACH_FLAG_FILE);
+        File configDir = DebugToolsPathUtils.getConfigDir();
+        return FileUtil.touch(new File(configDir, ProjectConstants.AUTO_ATTACH_FLAG_FILE).getPath());
     }
 
 }
+
+

--- a/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/utils/DebugToolsLibUtils.java
+++ b/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/utils/DebugToolsLibUtils.java
@@ -16,6 +16,7 @@
  */
 package io.github.future0923.debug.tools.base.utils;
 
+import io.github.future0923.debug.tools.base.constants.ProjectConstants;
 import io.github.future0923.debug.tools.base.logging.AnsiLog;
 
 import java.io.File;
@@ -31,11 +32,9 @@ public class DebugToolsLibUtils {
 
     static {
         String debugToolsLibDirEnv = System.getenv("DEBUG_TOOLS_HOME_DIR");
+        DEBUG_TOOLS_HOME_DIR = DebugToolsPathUtils.getLibHomeDir();
         if (debugToolsLibDirEnv != null) {
-            DEBUG_TOOLS_HOME_DIR = new File(debugToolsLibDirEnv);
-            AnsiLog.info("DEBUG_TOOLS_LIB_DIR: " + debugToolsLibDirEnv);
-        } else {
-            DEBUG_TOOLS_HOME_DIR = new File(System.getProperty("user.home") + File.separator + ".debugTools");
+            AnsiLog.info("DEBUG_TOOLS_HOME_DIR: " + debugToolsLibDirEnv);
         }
         try {
             DEBUG_TOOLS_HOME_DIR.mkdirs();
@@ -44,7 +43,7 @@ public class DebugToolsLibUtils {
         }
         if (!DEBUG_TOOLS_HOME_DIR.exists()) {
             // try to set a temp directory
-            DEBUG_TOOLS_HOME_DIR = new File(System.getProperty("java.io.tmpdir") + File.separator + ".debugTools");
+            DEBUG_TOOLS_HOME_DIR = new File(System.getProperty("java.io.tmpdir") + File.separator + ProjectConstants.NAME);
             try {
                 DEBUG_TOOLS_HOME_DIR.mkdirs();
             } catch (Throwable e) {

--- a/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/utils/DebugToolsPathUtils.java
+++ b/debug-tools-base/src/main/java/io/github/future0923/debug/tools/base/utils/DebugToolsPathUtils.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2024-2025 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.github.future0923.debug.tools.base.utils;
+
+import io.github.future0923.debug.tools.base.constants.ProjectConstants;
+
+import java.io.File;
+
+/**
+ * Resolve DebugTools directories with XDG-style layout across platforms.
+ *
+ * @author future0923
+ */
+public class DebugToolsPathUtils {
+
+    private static final String ENV_DEBUG_TOOLS_HOME_DIR = "DEBUG_TOOLS_HOME_DIR";
+    private static final String ENV_XDG_CONFIG_HOME = "XDG_CONFIG_HOME";
+    private static final String ENV_XDG_CACHE_HOME = "XDG_CACHE_HOME";
+    private static final String ENV_XDG_DATA_HOME = "XDG_DATA_HOME";
+    private static final String ENV_XDG_STATE_HOME = "XDG_STATE_HOME";
+
+    private DebugToolsPathUtils() {
+    }
+
+    public static File getConfigDir() {
+        if (!isXdgEnabled()) {
+            return getLegacyConfigDir();
+        }
+        return resolveXdgDir(ENV_XDG_CONFIG_HOME, ".config");
+    }
+
+    public static File getCacheDir() {
+        if (!isXdgEnabled()) {
+            return getLegacyConfigDir();
+        }
+        return resolveXdgDir(ENV_XDG_CACHE_HOME, ".cache");
+    }
+
+    public static File getDataDir() {
+        if (!isXdgEnabled()) {
+            return getLegacyConfigDir();
+        }
+        return resolveXdgDir(ENV_XDG_DATA_HOME, ".local" + File.separator + "share");
+    }
+
+    public static File getStateDir() {
+        if (!isXdgEnabled()) {
+            return getLegacyConfigDir();
+        }
+        return resolveXdgDir(ENV_XDG_STATE_HOME, ".local" + File.separator + "state");
+    }
+
+    public static File getLibHomeDir() {
+        String debugToolsHome = System.getenv(ENV_DEBUG_TOOLS_HOME_DIR);
+        if (isNotBlank(debugToolsHome)) {
+            return new File(debugToolsHome);
+        }
+        if (isXdgEnabled()) {
+            return getCacheDir();
+        }
+        return getLegacyLibDir();
+    }
+
+    public static File getLegacyConfigDir() {
+        String userHome = System.getProperty("user.home");
+        if (userHome == null) {
+            return new File(ProjectConstants.NAME);
+        }
+        return new File(userHome, ProjectConstants.NAME);
+    }
+
+    public static File getLegacyLibDir() {
+        String userHome = System.getProperty("user.home");
+        if (userHome == null) {
+            return new File(".debugTools");
+        }
+        return new File(userHome, ".debugTools");
+    }
+
+    private static boolean isXdgEnabled() {
+        return true;
+    }
+
+    private static File resolveXdgDir(String envVar, String fallbackRelative) {
+        String basePath = System.getenv(envVar);
+        File baseDir;
+        if (isNotBlank(basePath)) {
+            baseDir = new File(basePath);
+        } else {
+            String userHome = System.getProperty("user.home");
+            if (userHome == null) {
+                baseDir = new File(".");
+            } else {
+                baseDir = new File(userHome, fallbackRelative);
+            }
+        }
+        return new File(baseDir, ProjectConstants.NAME);
+    }
+
+    private static boolean isNotBlank(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}
+
+
+
+
+


### PR DESCRIPTION
## Summary
- 统一 DebugTools 配置/缓存目录为 XDG 风格路径（默认 .config/.cache/.local）
- 修复删除 .cache/DebugTools 后 lib 目录无法重建的问题
- 修复 debug-tools-attach 打包时复制 agent jar 的硬编码路径，跨平台可用

## Changes
- 新增 DebugToolsPathUtils 统一路径解析
- lib/临时依赖 -> XDG cache；配置/auto_attach -> XDG config
- createTempDir 改用 mkdirsSafely，避免父目录缺失导致失败
- debug-tools-attach/pom.xml 改为相对路径复制 agent jar

## Related
Fixes #248