### PR TITLE
fix(idea): avoid ui freeze during method execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ build/
 
 ### VS Code ###
 .vscode/
+.codex/
 
 ### Mac OS ###
 .DS_Store

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/combobox/ClassLoaderComboBox.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/combobox/ClassLoaderComboBox.java
@@ -22,22 +22,24 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
 import io.github.future0923.debug.tools.base.utils.DebugToolsThreadUtils;
 import io.github.future0923.debug.tools.common.protocal.http.AllClassLoaderRes;
-import io.github.future0923.debug.tools.idea.action.ExecuteLastWithDefaultClassLoaderEditorPopupMenuAction;
 import io.github.future0923.debug.tools.idea.client.http.HttpClientUtils;
 import io.github.future0923.debug.tools.idea.utils.StateUtils;
 
 import javax.swing.*;
 import java.awt.*;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author future0923
  */
 public class ClassLoaderComboBox extends ComboBox<AllClassLoaderRes.Item> {
 
-    private static final Logger logger = Logger.getInstance(ExecuteLastWithDefaultClassLoaderEditorPopupMenuAction.class);
+    private static final Logger logger = Logger.getInstance(ClassLoaderComboBox.class);
 
     private final Project project;
+
+    private final AtomicInteger refreshVersion = new AtomicInteger();
 
     public ClassLoaderComboBox(Project project) {
         this(project, -1, true);
@@ -75,11 +77,48 @@ public class ClassLoaderComboBox extends ComboBox<AllClassLoaderRes.Item> {
      * @param changeDefaultClassLoader 是否修改默认ClassLoader
      */
     public void refreshClassLoaderLater(boolean changeDefaultClassLoader) {
-        ApplicationManager.getApplication().invokeLater(() -> refreshClassLoader(changeDefaultClassLoader));
+        refreshClassLoader(changeDefaultClassLoader, null);
     }
 
     public void refreshClassLoader(boolean changeDefaultClassLoader) {
-        removeAllItems();
+        refreshClassLoader(changeDefaultClassLoader, null);
+    }
+
+    public void refreshClassLoader(boolean changeDefaultClassLoader, Runnable successUiCallback) {
+        int currentRefresh = refreshVersion.incrementAndGet();
+        ApplicationManager.getApplication().invokeLater(() -> {
+            removeAllItems();
+            setEnabled(false);
+        }, project.getDisposed());
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            AllClassLoaderRes allClassLoaderRes = loadAllClassLoader();
+            ApplicationManager.getApplication().invokeLater(() -> {
+                if (refreshVersion.get() != currentRefresh) {
+                    return;
+                }
+                removeAllItems();
+                if (allClassLoaderRes != null) {
+                    AllClassLoaderRes.Item defaultClassLoader = null;
+                    for (AllClassLoaderRes.Item item : allClassLoaderRes.getItemList()) {
+                        if (item.getIdentity().equals(allClassLoaderRes.getDefaultIdentity())) {
+                            defaultClassLoader = item;
+                        }
+                        addItem(item);
+                    }
+                    if (changeDefaultClassLoader && defaultClassLoader != null) {
+                        setSelectedItem(defaultClassLoader);
+                        StateUtils.setProjectDefaultClassLoader(project, defaultClassLoader);
+                    }
+                    if (successUiCallback != null) {
+                        successUiCallback.run();
+                    }
+                }
+                setEnabled(true);
+            }, project.getDisposed());
+        });
+    }
+
+    private AllClassLoaderRes loadAllClassLoader() {
         AllClassLoaderRes allClassLoaderRes = null;
         int retryCount = 0;
         while (!Thread.currentThread().isInterrupted() && retryCount < 20) {
@@ -90,23 +129,13 @@ public class ClassLoaderComboBox extends ComboBox<AllClassLoaderRes.Item> {
                 retryCount++;
             }
             if (!DebugToolsThreadUtils.sleep(1, TimeUnit.SECONDS)) {
-                return;
+                return null;
             }
         }
         if (allClassLoaderRes == null) {
-            return;
+            logger.warn("Failed to load classloader list after retries");
         }
-        AllClassLoaderRes.Item defaultClassLoader = null;
-        for (AllClassLoaderRes.Item item : allClassLoaderRes.getItemList()) {
-            if (item.getIdentity().equals(allClassLoaderRes.getDefaultIdentity())) {
-                defaultClassLoader = item;
-            }
-            addItem(item);
-        }
-        if (changeDefaultClassLoader && defaultClassLoader != null) {
-            setSelectedItem(defaultClassLoader);
-            StateUtils.setProjectDefaultClassLoader(project, defaultClassLoader);
-        }
+        return allClassLoaderRes;
     }
 
     public void setSelectedClassLoader(AllClassLoaderRes.Item identity) {

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/main/InvokeMethodRecordDialog.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/main/InvokeMethodRecordDialog.java
@@ -20,19 +20,17 @@ import com.intellij.icons.AllIcons;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
-import com.intellij.openapi.ui.Messages;
 import io.github.future0923.debug.tools.base.hutool.core.io.FileUtil;
 import io.github.future0923.debug.tools.base.hutool.core.util.StrUtil;
 import io.github.future0923.debug.tools.base.utils.DebugToolsDigestUtil;
 import io.github.future0923.debug.tools.common.dto.RunContentDTO;
 import io.github.future0923.debug.tools.common.dto.RunDTO;
 import io.github.future0923.debug.tools.common.dto.TraceMethodDTO;
-import io.github.future0923.debug.tools.common.exception.SocketCloseException;
 import io.github.future0923.debug.tools.common.protocal.http.AllClassLoaderRes;
 import io.github.future0923.debug.tools.common.protocal.packet.request.RunTargetMethodRequestPacket;
 import io.github.future0923.debug.tools.common.utils.DebugToolsJsonUtils;
 import io.github.future0923.debug.tools.idea.bundle.DebugToolsBundle;
-import io.github.future0923.debug.tools.idea.client.ApplicationProjectHolder;
+import io.github.future0923.debug.tools.idea.client.socket.utils.SocketSendUtils;
 import io.github.future0923.debug.tools.idea.constant.IdeaPluginProjectConstants;
 import io.github.future0923.debug.tools.idea.model.InvokeMethodRecordDTO;
 import io.github.future0923.debug.tools.idea.model.ParamCache;
@@ -91,6 +89,10 @@ public class InvokeMethodRecordDialog extends DialogWrapper {
         Map<String, String> itemHeaderMap = mainPanel.getItemHeaderMap();
         AllClassLoaderRes.Item classLoaderRes = (AllClassLoaderRes.Item) mainPanel.getClassLoaderComboBox().getSelectedItem();
         MainJsonEditor editor = mainPanel.getEditor();
+        if (editor.isGenerating()) {
+            DebugToolsNotifierUtil.notifyError(project, "参数正在生成，请稍后再试");
+            return;
+        }
         String text = DebugToolsJsonUtils.compress(editor.getText());
         String xxlJobParam = mainPanel.getXxlJobParamField().getText();
         TraceMethodPanel traceMethodPanel = mainPanel.getTraceMethodPanel();
@@ -137,48 +139,35 @@ public class InvokeMethodRecordDialog extends DialogWrapper {
             }
         }
         RunTargetMethodRequestPacket packet = new RunTargetMethodRequestPacket(runDTO);
-        ApplicationProjectHolder.Info info = ApplicationProjectHolder.getInfo(project);
-        if (info == null) {
-            Messages.showErrorDialog(DebugToolsBundle.message("dialog.error.run.attach.first"), DebugToolsBundle.message("dialog.title.execution.failed"));
-            DebugToolsToolWindowFactory.showWindow(project, null);
-            return;
-        }
-        try {
-            info.getClient().getHolder().send(packet);
-        } catch (SocketCloseException e) {
-            Messages.showErrorDialog(DebugToolsBundle.message("dialog.error.socket.close"), DebugToolsBundle.message("dialog.title.execution.failed"));
-            return;
-        } catch (Exception e) {
-            Messages.showErrorDialog(DebugToolsBundle.message("dialog.error.socket.send") + e.getMessage(), DebugToolsBundle.message("dialog.title.execution.failed"));
-            return;
-        }
         String runJsonStr = DebugToolsJsonUtils.toJsonStr(runDTO);
-        try {
-            String pathname = project.getBasePath() + IdeaPluginProjectConstants.PARAM_FILE;
-            File file = new File(pathname);
-            if (!file.exists()) {
-                FileUtils.touch(file);
+        SocketSendUtils.sendAsync(project, packet, () -> {
+            try {
+                String pathname = project.getBasePath() + IdeaPluginProjectConstants.PARAM_FILE;
+                File file = new File(pathname);
+                if (!file.exists()) {
+                    FileUtils.touch(file);
+                }
+                FileUtil.writeUtf8String(runJsonStr, file);
+            } catch (IOException ex) {
+                log.error("参数写入json文件失败", ex);
+                DebugToolsNotifierUtil.notifyError(project, "参数写入json文件失败");
+                return;
             }
-            FileUtil.writeUtf8String(runJsonStr, file);
-        } catch (IOException ex) {
-            log.error("参数写入json文件失败", ex);
-            DebugToolsNotifierUtil.notifyError(project, "参数写入json文件失败");
-            return;
-        }
-        if (settingState.getInvokeMethodRecord()) {
-            InvokeMethodRecordDTO invokeMethodRecordDTO = new InvokeMethodRecordDTO();
-            invokeMethodRecordDTO.setIdentity(recordRunDTO.getIdentity());
-            invokeMethodRecordDTO.formatRunTime();
-            invokeMethodRecordDTO.setClassName(runDTO.getTargetClassName());
-            invokeMethodRecordDTO.setClassSimpleName(recordRunDTO.getClassSimpleName());
-            invokeMethodRecordDTO.setMethodName(runDTO.getTargetMethodName());
-            invokeMethodRecordDTO.setMethodSignature(recordRunDTO.getMethodSignature());
-            invokeMethodRecordDTO.setMethodAroundName(methodAroundName);
-            invokeMethodRecordDTO.setMethodParamJson(text);
-            invokeMethodRecordDTO.setCacheKey(recordRunDTO.getCacheKey());
-            invokeMethodRecordDTO.formatRunDTO(runDTO);
-            DebugToolsToolWindowFactory.consumerInvokeMethodRecordPanel(project, panel -> panel.addItem(invokeMethodRecordDTO));
-        }
+            if (settingState.getInvokeMethodRecord()) {
+                InvokeMethodRecordDTO invokeMethodRecordDTO = new InvokeMethodRecordDTO();
+                invokeMethodRecordDTO.setIdentity(recordRunDTO.getIdentity());
+                invokeMethodRecordDTO.formatRunTime();
+                invokeMethodRecordDTO.setClassName(runDTO.getTargetClassName());
+                invokeMethodRecordDTO.setClassSimpleName(recordRunDTO.getClassSimpleName());
+                invokeMethodRecordDTO.setMethodName(runDTO.getTargetMethodName());
+                invokeMethodRecordDTO.setMethodSignature(recordRunDTO.getMethodSignature());
+                invokeMethodRecordDTO.setMethodAroundName(methodAroundName);
+                invokeMethodRecordDTO.setMethodParamJson(text);
+                invokeMethodRecordDTO.setCacheKey(recordRunDTO.getCacheKey());
+                invokeMethodRecordDTO.formatRunDTO(runDTO);
+                DebugToolsToolWindowFactory.consumerInvokeMethodRecordPanel(project, panel -> panel.addItem(invokeMethodRecordDTO));
+            }
+        });
         super.doOKAction();
     }
 

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/main/InvokeMethodRecordQuickPanel.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/main/InvokeMethodRecordQuickPanel.java
@@ -113,9 +113,7 @@ public class InvokeMethodRecordQuickPanel extends JBPanel<InvokeMethodRecordQuic
         JPanel classLoaderJPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
         getAllClassLoader();
         refreshButton.addActionListener(e -> {
-            classLoaderComboBox.removeAllItems();
             getAllClassLoader();
-            classLoaderComboBox.setSelectedClassLoader(StateUtils.getProjectDefaultClassLoader(project));
         });
         classLoaderJPanel.add(classLoaderComboBox);
         classLoaderJPanel.add(refreshButton);
@@ -195,8 +193,7 @@ public class InvokeMethodRecordQuickPanel extends JBPanel<InvokeMethodRecordQuic
     }
 
     private void getAllClassLoader() {
-        classLoaderComboBox.refreshClassLoader(false);
-        classLoaderComboBox.setSelectedClassLoader(StateUtils.getProjectDefaultClassLoader(project));
+        classLoaderComboBox.refreshClassLoader(false, () -> classLoaderComboBox.setSelectedClassLoader(StateUtils.getProjectDefaultClassLoader(project)));
     }
 
     public Map<String, String> getItemHeaderMap() {

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/main/MainDialog.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/main/MainDialog.java
@@ -91,6 +91,10 @@ public class MainDialog extends DialogWrapper {
         Map<String, String> itemHeaderMap = mainPanel.getItemHeaderMap();
         AllClassLoaderRes.Item classLoaderRes = (AllClassLoaderRes.Item) mainPanel.getClassLoaderComboBox().getSelectedItem();
         MainJsonEditor editor = mainPanel.getEditor();
+        if (editor.isGenerating()) {
+            DebugToolsNotifierUtil.notifyError(project, "参数正在生成，请稍后再试");
+            return;
+        }
         String text = DebugToolsJsonUtils.compress(editor.getText());
         String xxlJobParam = mainPanel.getXxlJobParamField().getText();
         TraceMethodPanel traceMethodPanel = mainPanel.getTraceMethodPanel();

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/main/MainJsonEditor.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/main/MainJsonEditor.java
@@ -16,19 +16,25 @@
  */
 package io.github.future0923.debug.tools.idea.ui.main;
 
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiParameterList;
+import com.intellij.util.concurrency.AppExecutorUtil;
 import io.github.future0923.debug.tools.common.utils.DebugToolsJsonUtils;
 import io.github.future0923.debug.tools.idea.setting.DebugToolsSettingState;
 import io.github.future0923.debug.tools.idea.setting.GenParamType;
 import io.github.future0923.debug.tools.idea.ui.editor.JsonEditor;
+import io.github.future0923.debug.tools.idea.utils.DebugToolsNotifierUtil;
 import io.github.future0923.debug.tools.idea.utils.DebugToolsJsonElementUtil;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.jps.incremental.GlobalContextKey;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author future0923
@@ -36,18 +42,25 @@ import org.jetbrains.jps.incremental.GlobalContextKey;
 @Getter
 public class MainJsonEditor extends JsonEditor {
 
+    private static final String STATUS_FIELD_NAME = "_status";
+
     private final PsiParameterList psiParameterList;
 
     public static final String FILE_NAME = "DebugToolsContentEditFile.json";
 
     public static final GlobalContextKey<PsiParameterList> DEBUG_POWER_EDIT_CONTENT = GlobalContextKey.create("DebugToolsEditContent");
 
+    private final AtomicInteger generationVersion = new AtomicInteger();
+
+    @Getter
+    private volatile boolean generating;
+
     public MainJsonEditor(String cacheText, PsiParameterList psiParameterList, Project project) {
         super(project, "");
         this.psiParameterList = psiParameterList;
         if (StringUtils.isBlank(cacheText)) {
             DebugToolsSettingState settingState = DebugToolsSettingState.getInstance(project);
-            setText(getJsonText(psiParameterList, settingState.getDefaultGenParamType()));
+            regenerateJsonText(settingState.getDefaultGenParamType(), true);
         } else {
             setText(cacheText);
         }
@@ -58,15 +71,65 @@ public class MainJsonEditor extends JsonEditor {
     }
 
     public void regenerateJsonText(GenParamType type) {
-        if (GenParamType.SIMPLE.equals(type)) {
-            setText(DebugToolsJsonElementUtil.getSimpleText(psiParameterList));
-        } else {
-            setText(getJsonText(psiParameterList, type));
-        }
+        regenerateJsonText(type, false);
     }
 
     public void prettyJsonText() {
         setText(DebugToolsJsonUtils.pretty(getText()));
+    }
+
+    private void regenerateJsonText(GenParamType type, boolean preserveManualText) {
+        int currentGenerationVersion = generationVersion.incrementAndGet();
+        String previousText = getText();
+        String loadingText = statusText("Generating parameters...");
+        generating = true;
+        setText(loadingText);
+        ReadAction.nonBlocking(() -> buildJsonResult(type))
+                .withDocumentsCommitted(getProject())
+                .finishOnUiThread(ModalityState.any(), result -> {
+                    if (generationVersion.get() != currentGenerationVersion) {
+                        return;
+                    }
+                    generating = false;
+                    if (preserveManualText && !StringUtils.equals(getText(), loadingText)) {
+                        return;
+                    }
+                    if (result.success()) {
+                        setText(result.text());
+                    } else {
+                        if (preserveManualText) {
+                            setText("{}");
+                        } else {
+                            setText(previousText);
+                        }
+                        DebugToolsNotifierUtil.notifyError(getProject(), result.errorMessage());
+                    }
+                })
+                .submit(AppExecutorUtil.getAppExecutorService());
+    }
+
+    private GenerateResult buildJsonResult(GenParamType type) {
+        if (psiParameterList == null) {
+            return new GenerateResult(null, "当前记录缺少方法参数信息，无法重新生成参数", false);
+        }
+        try {
+            String text;
+            if (GenParamType.SIMPLE.equals(type)) {
+                text = DebugToolsJsonElementUtil.getSimpleText(psiParameterList);
+            } else {
+                text = getJsonText(psiParameterList, type);
+            }
+            return new GenerateResult(text, null, true);
+        } catch (Exception ex) {
+            return new GenerateResult(null, "参数生成失败: " + ex.getMessage(), false);
+        }
+    }
+
+    private String statusText(String status) {
+        return DebugToolsJsonUtils.createJsonObject().set(STATUS_FIELD_NAME, status).toJSONString(4);
+    }
+
+    private record GenerateResult(String text, String errorMessage, boolean success) {
     }
 
     @Override

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/main/MainPanel.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/main/MainPanel.java
@@ -126,9 +126,7 @@ public class MainPanel extends JBPanel<MainPanel> {
         JPanel classLoaderJPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
         getAllClassLoader();
         refreshButton.addActionListener(e -> {
-            classLoaderComboBox.removeAllItems();
             getAllClassLoader();
-            classLoaderComboBox.setSelectedClassLoader(StateUtils.getProjectDefaultClassLoader(project));
         });
         classLoaderJPanel.add(classLoaderComboBox);
         classLoaderJPanel.add(refreshButton);
@@ -211,8 +209,7 @@ public class MainPanel extends JBPanel<MainPanel> {
     }
 
     private void getAllClassLoader() {
-        classLoaderComboBox.refreshClassLoader(false);
-        classLoaderComboBox.setSelectedClassLoader(StateUtils.getProjectDefaultClassLoader(project));
+        classLoaderComboBox.refreshClassLoader(false, () -> classLoaderComboBox.setSelectedClassLoader(StateUtils.getProjectDefaultClassLoader(project)));
     }
 
     public Map<String, String> getItemHeaderMap() {

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/tab/ExceptionTabbedPane.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/tab/ExceptionTabbedPane.java
@@ -17,6 +17,7 @@
 package io.github.future0923.debug.tools.idea.ui.tab;
 
 import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.ui.components.JBPanel;
@@ -51,6 +52,8 @@ public class ExceptionTabbedPane extends JBPanel<ExceptionTabbedPane> {
 
     private boolean loadDebug = false;
 
+    private boolean loadingDebug = false;
+
     public ExceptionTabbedPane(Project project, String throwable, String offsetPath) {
         this.project = project;
         this.throwable = throwable;
@@ -81,19 +84,31 @@ public class ExceptionTabbedPane extends JBPanel<ExceptionTabbedPane> {
             int selectedIndex = tabPane.getSelectedIndex();
             // 获取当前选中的选项卡标题
             //String selectedTabTitle = tabPane.getTitleAt(selectedIndex);
-            if (selectedIndex == 1 && !loadDebug) {
+            if (selectedIndex == 1 && !loadDebug && !loadingDebug) {
                 changeDebug();
             }
         });
     }
 
     private void changeDebug() {
-        String body = HttpClientUtils.resultType(project, offsetPath, PrintResultType.DEBUG.getType());
-        if (DebugToolsStringUtils.isNotBlank(body)) {
-            debugTab.setRoot(new ResultDebugTreeNode(DebugToolsJsonUtils.toBean(body, RunResultDTO.class)));
-            loadDebug = true;
-        } else {
-            Messages.showErrorDialog(project, "The request failed, please try again later", "Exception Result");
-        }
+        loadingDebug = true;
+        debugTab.setRoot(createStatusNode("Loading..."));
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            String body = HttpClientUtils.resultType(project, offsetPath, PrintResultType.DEBUG.getType());
+            ApplicationManager.getApplication().invokeLater(() -> {
+                loadingDebug = false;
+                if (DebugToolsStringUtils.isNotBlank(body)) {
+                    debugTab.setRoot(new ResultDebugTreeNode(DebugToolsJsonUtils.toBean(body, RunResultDTO.class)));
+                    loadDebug = true;
+                } else {
+                    debugTab.setRoot(createStatusNode("Load failed"));
+                    Messages.showErrorDialog(project, "The request failed, please try again later", "Exception Result");
+                }
+            }, project.getDisposed());
+        });
+    }
+
+    private ResultDebugTreeNode createStatusNode(String message) {
+        return new ResultDebugTreeNode(new RunResultDTO("result", message), true);
     }
 }

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/tab/ResultTabbedPane.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/tab/ResultTabbedPane.java
@@ -16,12 +16,14 @@
  */
 package io.github.future0923.debug.tools.idea.ui.tab;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.ui.components.JBPanel;
 import com.intellij.ui.components.JBTabbedPane;
 import io.github.future0923.debug.tools.base.hutool.core.collection.CollUtil;
 import io.github.future0923.debug.tools.base.hutool.core.util.StrUtil;
+import io.github.future0923.debug.tools.base.trace.MethodTraceType;
 import io.github.future0923.debug.tools.base.trace.MethodTreeNode;
 import io.github.future0923.debug.tools.base.utils.DebugToolsStringUtils;
 import io.github.future0923.debug.tools.common.dto.RunResultDTO;
@@ -70,6 +72,12 @@ public class ResultTabbedPane extends JBPanel<ResultTabbedPane> {
     private boolean loadDebug = false;
 
     private boolean loadTrace = false;
+
+    private boolean loadingJson = false;
+
+    private boolean loadingDebug = false;
+
+    private boolean loadingTrace = false;
 
     public ResultTabbedPane(Project project, String printResult, String offsetPath, String traceOffsetPath, ResultClassType resultClassType) {
         this.project = project;
@@ -131,11 +139,11 @@ public class ResultTabbedPane extends JBPanel<ResultTabbedPane> {
             int selectedIndex = tabPane.getSelectedIndex();
             // 获取当前选中的选项卡标题
             String selectedTabTitle = tabPane.getTitleAt(selectedIndex);
-            if (Objects.equals(selectedTabTitle, "json") && !loadJson) {
+            if (Objects.equals(selectedTabTitle, "json") && !loadJson && !loadingJson) {
                 changeJson();
-            } else if (Objects.equals(selectedTabTitle, "debug") && !loadDebug) {
+            } else if (Objects.equals(selectedTabTitle, "debug") && !loadDebug && !loadingDebug) {
                 changeDebug();
-            } else if (Objects.equals(selectedTabTitle, "trace") && !loadTrace) {
+            } else if (Objects.equals(selectedTabTitle, "trace") && !loadTrace && !loadingTrace) {
                 changeTrace();
             }
         });
@@ -150,7 +158,17 @@ public class ResultTabbedPane extends JBPanel<ResultTabbedPane> {
         } else if (ResultClassType.SIMPLE.equals(resultClassType)) {
             text = "{\n    \"result\": \"" + printResult + "\"\n}";
         } else if (ResultClassType.OBJECT.equals(resultClassType)) {
-            text = HttpClientUtils.resultType(project, offsetPath, PrintResultType.JSON.getType());
+            loadingJson = true;
+            jsonTab.setText(statusJson("Loading..."));
+            ApplicationManager.getApplication().executeOnPooledThread(() -> {
+                String body = HttpClientUtils.resultType(project, offsetPath, PrintResultType.JSON.getType());
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    loadingJson = false;
+                    loadJson = true;
+                    jsonTab.setText(body);
+                }, project.getDisposed());
+            });
+            return;
         }
         jsonTab.setText(text);
         loadJson = true;
@@ -161,22 +179,30 @@ public class ResultTabbedPane extends JBPanel<ResultTabbedPane> {
             return;
         }
         if (ResultClassType.VOID.equals(resultClassType)) {
-            Messages.showErrorDialog(project, "Void does not support viewing", "Debug Result");
+            debugTab.setRoot(createDebugStatusNode("Void does not support viewing"));
+            loadDebug = true;
         } else if (ResultClassType.NULL.equals(resultClassType)) {
-            Messages.showErrorDialog(project, "Null does not support viewing", "Debug Result");
+            debugTab.setRoot(createDebugStatusNode("Null does not support viewing"));
+            loadDebug = true;
         } else if (ResultClassType.SIMPLE.equals(resultClassType)) {
-            debugTab.setRoot(new ResultDebugTreeNode(new RunResultDTO("result", printResult) {{
-                setLeaf(true);
-            }}));
+            debugTab.setRoot(createDebugStatusNode(printResult));
             loadDebug = true;
         } else if (ResultClassType.OBJECT.equals(resultClassType)) {
-            String body = HttpClientUtils.resultType(project, offsetPath, PrintResultType.DEBUG.getType());
-            if (DebugToolsStringUtils.isNotBlank(body)) {
-                debugTab.setRoot(new ResultDebugTreeNode(DebugToolsJsonUtils.toBean(body, RunResultDTO.class)));
-                loadDebug = true;
-            } else {
-                Messages.showErrorDialog(project, "The request failed, please try again later", "Request Result");
-            }
+            loadingDebug = true;
+            debugTab.setRoot(createDebugStatusNode("Loading..."));
+            ApplicationManager.getApplication().executeOnPooledThread(() -> {
+                String body = HttpClientUtils.resultType(project, offsetPath, PrintResultType.DEBUG.getType());
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    loadingDebug = false;
+                    if (DebugToolsStringUtils.isNotBlank(body)) {
+                        debugTab.setRoot(new ResultDebugTreeNode(DebugToolsJsonUtils.toBean(body, RunResultDTO.class)));
+                        loadDebug = true;
+                    } else {
+                        debugTab.setRoot(createDebugStatusNode("Load failed"));
+                        Messages.showErrorDialog(project, "The request failed, please try again later", "Request Result");
+                    }
+                }, project.getDisposed());
+            });
         }
     }
 
@@ -185,12 +211,48 @@ public class ResultTabbedPane extends JBPanel<ResultTabbedPane> {
             return;
         }
         if (StrUtil.isBlank(traceOffsetPath)) {
-            Messages.showErrorDialog(project, "Trace does not support viewing", "Debug Result");
+            traceTab.setRoot(createTraceStatusNode("Trace does not support viewing"));
+            loadTrace = true;
+            return;
         }
-        List<MethodTreeNode> methodTreeNodes = HttpClientUtils.resultTrace(project, traceOffsetPath);
-        if (CollUtil.isNotEmpty(methodTreeNodes)) {
-            traceTab.setRoot(new ResultTraceTreeNode(CollUtil.getFirst(methodTreeNodes)));
-        }
-        loadTrace = true;
+        loadingTrace = true;
+        traceTab.setRoot(createTraceStatusNode("Loading..."));
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                List<MethodTreeNode> methodTreeNodes = HttpClientUtils.resultTrace(project, traceOffsetPath);
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    loadingTrace = false;
+                    if (CollUtil.isNotEmpty(methodTreeNodes)) {
+                        traceTab.setRoot(new ResultTraceTreeNode(CollUtil.getFirst(methodTreeNodes)));
+                    } else {
+                        traceTab.setRoot(createTraceStatusNode("No trace data"));
+                    }
+                    loadTrace = true;
+                }, project.getDisposed());
+            } catch (Exception ex) {
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    loadingTrace = false;
+                    traceTab.setRoot(createTraceStatusNode("Load failed"));
+                    Messages.showErrorDialog(project, "The request failed, please try again later", "Trace Result");
+                }, project.getDisposed());
+            }
+        });
+    }
+
+    private String statusJson(String result) {
+        return "{\n    \"result\": \"" + result + "\"\n}";
+    }
+
+    private ResultDebugTreeNode createDebugStatusNode(String message) {
+        return new ResultDebugTreeNode(new RunResultDTO("result", message), true);
+    }
+
+    private ResultTraceTreeNode createTraceStatusNode(String message) {
+        MethodTreeNode methodTreeNode = new MethodTreeNode();
+        methodTreeNode.setTraceType(MethodTraceType.METHOD);
+        methodTreeNode.setClassSimpleName("status");
+        methodTreeNode.setMethodSignature(message);
+        methodTreeNode.setDuration(0L);
+        return new ResultTraceTreeNode(methodTreeNode);
     }
 }

--- a/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/tree/ResultDebugTreePanel.java
+++ b/debug-tools-idea/src/main/java/io/github/future0923/debug/tools/idea/ui/tree/ResultDebugTreePanel.java
@@ -16,7 +16,9 @@
  */
 package io.github.future0923.debug.tools.idea.ui.tree;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
 import com.intellij.ui.border.CustomLineBorder;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.treeStructure.SimpleTree;
@@ -48,6 +50,8 @@ import java.util.List;
 @SuppressWarnings(value = {"unchecked", "rawtypes"})
 public class ResultDebugTreePanel extends JBScrollPane {
 
+    private final Project project;
+
     private final Tree tree;
 
     public ResultDebugTreePanel(Project project) {
@@ -55,6 +59,7 @@ public class ResultDebugTreePanel extends JBScrollPane {
     }
 
     public ResultDebugTreePanel(Project project, ResultDebugTreeNode root) {
+        this.project = project;
         this.tree = new SimpleTree();
         // 可以拖动的Tree SimpleDnDAwareTree
         this.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
@@ -67,12 +72,7 @@ public class ResultDebugTreePanel extends JBScrollPane {
             public void treeWillExpand(TreeExpansionEvent event) throws ExpandVetoException {
                 if (event.getPath().getLastPathComponent() instanceof TreeNode node) {
                     if (node.getChildCount() == 1 && node.getFirstChild() instanceof EmptyTreeNode) {
-                        node.removeAllChildren();
-                        List<RunResultDTO> runResultDTOList = HttpClientUtils.resultDetail(project, ((RunResultDTO)node.getUserObject()).getFiledOffset());
-                        for (RunResultDTO runResultDTO : runResultDTOList) {
-                            node.add(new ResultDebugTreeNode(runResultDTO, runResultDTO.getLeaf()));
-                        }
-                        ((DefaultTreeModel) tree.getModel()).reload(node);
+                        loadChildren(node);
                     }
                 }
             }
@@ -133,6 +133,40 @@ public class ResultDebugTreePanel extends JBScrollPane {
             StringSelection stringSelection = new StringSelection(value ? runResultDTO.getValue() == null ? "null" : runResultDTO.getValue() : runResultDTO.getName() == null ? "null" : runResultDTO.getName());
             Toolkit.getDefaultToolkit().getSystemClipboard().setContents(stringSelection, null);
         }
+    }
+
+    private void loadChildren(TreeNode<RunResultDTO> node) {
+        DefaultTreeModel model = (DefaultTreeModel) tree.getModel();
+        node.removeAllChildren();
+        node.add(createStatusNode("Loading..."));
+        model.reload(node);
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                List<RunResultDTO> runResultDTOList = HttpClientUtils.resultDetail(project, node.getUserObject().getFiledOffset());
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    node.removeAllChildren();
+                    if (runResultDTOList == null || runResultDTOList.isEmpty()) {
+                        node.add(createStatusNode("No data"));
+                    } else {
+                        for (RunResultDTO runResultDTO : runResultDTOList) {
+                            node.add(new ResultDebugTreeNode(runResultDTO, runResultDTO.getLeaf()));
+                        }
+                    }
+                    model.reload(node);
+                }, project.getDisposed());
+            } catch (Exception ex) {
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    node.removeAllChildren();
+                    node.add(new EmptyTreeNode());
+                    model.reload(node);
+                    Messages.showErrorDialog(project, "The request failed, please try again later", "Debug Result");
+                }, project.getDisposed());
+            }
+        });
+    }
+
+    private ResultDebugTreeNode createStatusNode(String message) {
+        return new ResultDebugTreeNode(new RunResultDTO("status", message, RunResultDTO.Type.PROPERTY, null), true);
     }
 
     public void setRoot(ResultDebugTreeNode root) {


### PR DESCRIPTION
## What
- move several IntelliJ plugin UI-blocking operations off the EDT
- generate parameter JSON asynchronously and block execution while generation is still running
- load classloaders, result tabs, and debug tree children asynchronously
- add `.codex/` to `.gitignore`

## Why
Clicking method execution or opening result/debug related views could freeze the whole IDEA window for a long time. This change reduces those UI freeze risks by moving blocking work to background threads and updating the UI on completion.

## Verification
- build plugin dependencies locally with Maven
- `:debug-tools-idea:compileJava` passed
- rebuilt plugin package successfully
