### PR TITLE
fix: 修复 SqlDriverClassFileTransformer 导致 Spring Boot 启动偶发死锁

### DIFF
--- a/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/DataSourceDriverClassEnum.java
+++ b/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/DataSourceDriverClassEnum.java
@@ -24,10 +24,7 @@ import io.github.future0923.debug.tools.base.hutool.core.util.StrUtil;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 
 
 public enum DataSourceDriverClassEnum {
@@ -37,7 +34,6 @@ public enum DataSourceDriverClassEnum {
     MYSQL(
             "mysql",
             "com.mysql",
-            Arrays.asList("com.mysql.jdbc.NonRegisteringDriver", "com.mysql.cj.jdbc.NonRegisteringDriver"),
             (sta, parameters) -> {
                 String sql = sta.toString().replace("** BYTE ARRAY DATA **", "NULL");
                 return sql.replace("com.mysql.jdbc.ClientPreparedStatement:", "")
@@ -53,7 +49,6 @@ public enum DataSourceDriverClassEnum {
     POSTGRESQL(
             "postgresql",
             "org.postgresql",
-            Collections.singletonList("org.postgresql.Driver"),
             (sta, parameters) -> formatStringSql(sta.toString(), parameters)
     ),
 
@@ -63,7 +58,6 @@ public enum DataSourceDriverClassEnum {
     KINGBASE(
             "kingbase",
             "com.kingbase8",
-            Collections.singletonList("com.kingbase8.Driver"),
             (sta, parameters) -> formatStringSql(sta.toString(), parameters)
     ),
 
@@ -73,7 +67,6 @@ public enum DataSourceDriverClassEnum {
     SQLSERVER(
             "sqlserver",
             "com.microsoft.sqlserver",
-            Collections.singletonList("com.microsoft.sqlserver.jdbc.SQLServerDriver"),
             (sta, parameters) -> {
                 Object[] inOutParam = (Object[]) ReflectUtil.getFieldValue(sta, "inOutParam");
                 Object[] parameterValues = new Object[inOutParam.length];
@@ -90,7 +83,6 @@ public enum DataSourceDriverClassEnum {
     CLICKHOUSE(
             "clickhouse",
             "com.clickhouse",
-            Collections.singletonList("com.clickhouse.jdbc.Driver"),
             (sta, parameters) -> sta.toString()
     ),
 
@@ -100,7 +92,6 @@ public enum DataSourceDriverClassEnum {
     ORACLE(
             "oracle",
             "oracle.jdbc",
-            Collections.singletonList("oracle.jdbc.driver.OracleDriver"),
             (sta, parameters) -> {
                 String statementQuery = ReflectUtil.getFieldValue(ReflectUtil.getFieldValue(sta, "preparedStatement"), "sqlObject").toString();
                 return formatStringSql(statementQuery, parameters);
@@ -113,7 +104,6 @@ public enum DataSourceDriverClassEnum {
     DM(
             "dm",
             "dm.jdbc",
-            Collections.singletonList("dm.jdbc.driver.DmDriver"),
             (sta, parameters) -> {
                 String statementQuery;
                 Object rpstmt = ReflectUtil.getFieldValue(sta, "rpstmt");
@@ -127,10 +117,9 @@ public enum DataSourceDriverClassEnum {
     ),
     ;
 
-    DataSourceDriverClassEnum(String type, String packagePrefix, List<String> driverClassName, SqlFormat format) {
+    DataSourceDriverClassEnum(String type, String packagePrefix, SqlFormat format) {
         this.type = type;
         this.packagePrefix = packagePrefix;
-        this.driverClassName = driverClassName;
         this.format = format;
     }
 
@@ -144,7 +133,6 @@ public enum DataSourceDriverClassEnum {
 
     private final String type;
     private final String packagePrefix;
-    private final List<String> driverClassName;
     private final SqlFormat format;
 
     /**
@@ -192,11 +180,12 @@ public enum DataSourceDriverClassEnum {
         if (StrUtil.isBlank(statementClassName)) {
             return null;
         }
-        return Arrays
-                .stream(DataSourceDriverClassEnum.values())
-                .filter(dbType -> statementClassName.startsWith(dbType.packagePrefix))
-                .findFirst()
-                .orElse(null);
+        for (DataSourceDriverClassEnum dbType : values()) {
+            if (statementClassName.startsWith(dbType.packagePrefix)) {
+                return dbType;
+            }
+        }
+        return null;
     }
 
     /**
@@ -209,9 +198,7 @@ public enum DataSourceDriverClassEnum {
         if (StrUtil.isBlank(className)) {
             return Boolean.FALSE;
         }
-        return Arrays
-                .stream(DataSourceDriverClassEnum.values())
-                .anyMatch(dbType -> dbType.driverClassName.contains(className));
+        return JdbcDriverClasses.isDriverClass(className);
     }
 
     /**
@@ -224,11 +211,6 @@ public enum DataSourceDriverClassEnum {
         if (StrUtil.isBlank(className)) {
             return "";
         }
-        return Arrays
-                .stream(DataSourceDriverClassEnum.values())
-                .filter(dbType -> dbType.driverClassName.contains(className))
-                .findFirst()
-                .map(DataSourceDriverClassEnum::getType)
-                .orElse("");
+        return JdbcDriverClasses.getDriverType(className);
     }
 }

--- a/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/JdbcDriverClasses.java
+++ b/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/JdbcDriverClasses.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024-2025 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.github.future0923.debug.tools.sql;
+
+/**
+ * JDBC 驱动类全限定名常量。
+ * <p>
+ * 独立于 {@link DataSourceDriverClassEnum}，不依赖 hutool 等外部库，
+ * 确保 {@link SqlDriverClassFileTransformer} 在 ClassFileTransformer 上下文中
+ * 调用时不会触发额外的类加载导致死锁。
+ *
+ * @author C.
+ */
+class JdbcDriverClasses {
+
+    static final String[][] DRIVER_MAPPING = {
+            {"com.mysql.jdbc.NonRegisteringDriver", "mysql"},
+            {"com.mysql.cj.jdbc.NonRegisteringDriver", "mysql"},
+            {"org.postgresql.Driver", "postgresql"},
+            {"com.kingbase8.Driver", "kingbase"},
+            {"com.microsoft.sqlserver.jdbc.SQLServerDriver", "sqlserver"},
+            {"com.clickhouse.jdbc.Driver", "clickhouse"},
+            {"oracle.jdbc.driver.OracleDriver", "oracle"},
+            {"dm.jdbc.driver.DmDriver", "dm"}
+    };
+
+    static boolean isDriverClass(String className) {
+        for (String[] entry : DRIVER_MAPPING) {
+            if (entry[0].equals(className)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static String getDriverType(String className) {
+        for (String[] entry : DRIVER_MAPPING) {
+            if (entry[0].equals(className)) {
+                return entry[1];
+            }
+        }
+        return "";
+    }
+
+    private JdbcDriverClasses() {
+    }
+}

--- a/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/SqlDriverClassFileTransformer.java
+++ b/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/SqlDriverClassFileTransformer.java
@@ -17,11 +17,11 @@
 package io.github.future0923.debug.tools.sql;
 
 import io.github.future0923.debug.tools.base.logging.Logger;
-import io.github.future0923.debug.tools.hotswap.core.util.JavassistUtil;
 import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.CtMethod;
 
+import java.io.ByteArrayInputStream;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.security.ProtectionDomain;
@@ -34,6 +34,22 @@ public class SqlDriverClassFileTransformer implements ClassFileTransformer {
 
     private static final Logger logger = Logger.getLogger(SqlDriverClassFileTransformer.class);
 
+    /**
+     * JDBC 驱动类全限定名，用于 transformer 内的纯字符串匹配。
+     * 不能调用 DataSourceDriverClassEnum，否则会触发枚举类及其依赖的 hutool 类加载，
+     * 在 transformer 内形成递归类加载死锁。
+     */
+    private static final String[] TARGET_DRIVERS = {
+            "com.mysql.jdbc.NonRegisteringDriver",
+            "com.mysql.cj.jdbc.NonRegisteringDriver",
+            "org.postgresql.Driver",
+            "com.kingbase8.Driver",
+            "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+            "com.clickhouse.jdbc.Driver",
+            "oracle.jdbc.driver.OracleDriver",
+            "dm.jdbc.driver.DmDriver"
+    };
+
     @Override
     public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
         try {
@@ -41,19 +57,34 @@ public class SqlDriverClassFileTransformer implements ClassFileTransformer {
                 return null;
             }
             String dotClassName = className.replace('/', '.');
-            if (!DataSourceDriverClassEnum.isTargetDriver(dotClassName)) {
+            if (!isTargetDriver(dotClassName)) {
                 return null;
             }
-            ClassPool classPool = JavassistUtil.getClassPool(loader);
-            CtClass ctClass = classPool.get(dotClassName);
+            ClassPool classPool = new ClassPool();
+            classPool.appendSystemPath();
+            CtClass ctClass = classPool.makeClass(new ByteArrayInputStream(classfileBuffer));
             CtMethod connectMethod = ctClass.getDeclaredMethod("connect", new CtClass[]{classPool.get("java.lang.String"), classPool.get("java.util.Properties")});
             connectMethod.insertAfter(buildProxyConnectionCode());
-            logger.info("Print {} log bytecode enhancement successful", DataSourceDriverClassEnum.getSqlDriverType(dotClassName));
-            return ctClass.toBytecode();
+            logger.info("Print {} log bytecode enhancement successful", dotClassName);
+            byte[] result = ctClass.toBytecode();
+            ctClass.detach();
+            return result;
         } catch (Throwable t) {
             logger.error("Failed to print SQL log bytecode enhancement", t);
         }
         return null;
+    }
+
+    /**
+     * 纯字符串匹配，不引用任何外部类，避免 transformer 内类加载死锁
+     */
+    private static boolean isTargetDriver(String dotClassName) {
+        for (String driver : TARGET_DRIVERS) {
+            if (driver.equals(dotClassName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private String buildProxyConnectionCode() {

--- a/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/SqlDriverClassFileTransformer.java
+++ b/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/SqlDriverClassFileTransformer.java
@@ -34,22 +34,6 @@ public class SqlDriverClassFileTransformer implements ClassFileTransformer {
 
     private static final Logger logger = Logger.getLogger(SqlDriverClassFileTransformer.class);
 
-    /**
-     * JDBC 驱动类全限定名，用于 transformer 内的纯字符串匹配。
-     * 不能调用 DataSourceDriverClassEnum，否则会触发枚举类及其依赖的 hutool 类加载，
-     * 在 transformer 内形成递归类加载死锁。
-     */
-    private static final String[] TARGET_DRIVERS = {
-            "com.mysql.jdbc.NonRegisteringDriver",
-            "com.mysql.cj.jdbc.NonRegisteringDriver",
-            "org.postgresql.Driver",
-            "com.kingbase8.Driver",
-            "com.microsoft.sqlserver.jdbc.SQLServerDriver",
-            "com.clickhouse.jdbc.Driver",
-            "oracle.jdbc.driver.OracleDriver",
-            "dm.jdbc.driver.DmDriver"
-    };
-
     @Override
     public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
         try {
@@ -57,7 +41,7 @@ public class SqlDriverClassFileTransformer implements ClassFileTransformer {
                 return null;
             }
             String dotClassName = className.replace('/', '.');
-            if (!isTargetDriver(dotClassName)) {
+            if (!JdbcDriverClasses.isDriverClass(dotClassName)) {
                 return null;
             }
             ClassPool classPool = new ClassPool();
@@ -65,7 +49,7 @@ public class SqlDriverClassFileTransformer implements ClassFileTransformer {
             CtClass ctClass = classPool.makeClass(new ByteArrayInputStream(classfileBuffer));
             CtMethod connectMethod = ctClass.getDeclaredMethod("connect", new CtClass[]{classPool.get("java.lang.String"), classPool.get("java.util.Properties")});
             connectMethod.insertAfter(buildProxyConnectionCode());
-            logger.info("Print {} log bytecode enhancement successful", dotClassName);
+            logger.info("Print {} log bytecode enhancement successful", JdbcDriverClasses.getDriverType(dotClassName));
             byte[] result = ctClass.toBytecode();
             ctClass.detach();
             return result;
@@ -73,18 +57,6 @@ public class SqlDriverClassFileTransformer implements ClassFileTransformer {
             logger.error("Failed to print SQL log bytecode enhancement", t);
         }
         return null;
-    }
-
-    /**
-     * 纯字符串匹配，不引用任何外部类，避免 transformer 内类加载死锁
-     */
-    private static boolean isTargetDriver(String dotClassName) {
-        for (String driver : TARGET_DRIVERS) {
-            if (driver.equals(dotClassName)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private String buildProxyConnectionCode() {


### PR DESCRIPTION
## 问题描述

使用 javaagent 方式引入 debug-tools-agent 后，Spring Boot 应用偶发性启动卡死（约 10~20 次出现 1 次）。

## 环境

- JDK 21 (jdk-21.0.9)
- Spring Boot 2.x / 3.x
- debug-tools 5.0.1

## 根因分析

SqlDriverClassFileTransformer 作为 ClassFileTransformer 注册后，JVM 加载每个类时都会调用其 transform() 方法，此时 JVM 已持有当前类加载器的锁。

transform() 内部调用了 DataSourceDriverClassEnum.isTargetDriver()，该枚举类的静态初始化会加载 hutool 工具类链（Convert、ReflectUtil、StrUtil 等）。这些额外的类加载在同一线程中需要再次获取类加载器锁，与另一个正在并行加载类的线程形成锁竞争，导致死锁。

```
Thread A (加载 hutool 类)              Thread B (加载其他类)
─────────────────────────              ─────────────────────────
1. 持有 classloader 锁                  1. 持有 JVM define 锁
2. define -> 触发 transformer            2. classloader.loadClass()
3. 需要 JVM define 锁 <- 阻塞            3. 需要 classloader 锁 <- 阻塞
        ^                                        ^
        +---------- 互相等待，死锁 ---------------+
```

## 复现方式

1. 使用 javaagent 方式引入 debug-tools-agent
2. 在 IDEA 插件中开启 SQL 打印功能（printSql=Pretty）
3. 启动 Spring Boot 应用
4. 反复重启 10~20 次，偶发卡死在启动阶段

## 修复方案

### 1. 核心修复：消除 transformer 内的额外类加载

修改 SqlDriverClassFileTransformer，确保 transform() 方法内不触发任何额外的类加载：

- **DataSourceDriverClassEnum.isTargetDriver()** -> 新增 JdbcDriverClasses 常量类，纯字符串匹配，无 hutool 依赖
- **JavassistUtil.getClassPool(loader)** -> 改为 new ClassPool() + appendSystemPath()，不使用 LoaderClassPath
- **classPool.get(dotClassName)** -> 改为 classPool.makeClass(ByteArrayInputStream(classfileBuffer))，直接从字节码创建 CtClass

### 2. 重构：消除重复数据

新增 JdbcDriverClasses 常量类，集中管理 JDBC 驱动类名与类型映射，DataSourceDriverClassEnum 复用该常量，避免两处维护相同数据。