### PR TITLE
feat(sql): support GBase 8s (gbasedbt) SQL print

### DIFF
--- a/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/DataSourceDriverClassEnum.java
+++ b/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/DataSourceDriverClassEnum.java
@@ -62,6 +62,20 @@ public enum DataSourceDriverClassEnum {
     ),
 
     /**
+     * GBase 8s（产品线 gbasedbt，驱动 gbasedbtjdbc）。
+     * <p>
+     * 驱动 {@code com.gbasedbt.jdbc.Driver} 的 PreparedStatement 为
+     * {@code com.gbasedbt.jdbc.IfxPreparedStatement}，{@code toString()} 不可直接用。
+     * SQL 字段名跨版本混淆且父类可能存在同名非 String 字段（如 3.6.5 的 short v），
+     * 统一交给 {@link GbaseSqlSupport#extractSql(Statement)} 提取后再填充参数。
+     */
+    GBASEDBT(
+            "gbasedbt",
+            "com.gbasedbt",
+            (sta, parameters) -> formatStringSql(GbaseSqlSupport.extractSql(sta), parameters)
+    ),
+
+    /**
      * sqlserver
      */
     SQLSERVER(

--- a/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/GbaseSqlSupport.java
+++ b/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/GbaseSqlSupport.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2024-2025 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.github.future0923.debug.tools.sql;
+
+import io.github.future0923.debug.tools.base.hutool.core.util.ReflectUtil;
+import io.github.future0923.debug.tools.base.hutool.core.util.StrUtil;
+
+import java.lang.reflect.Field;
+import java.sql.Statement;
+
+/**
+ * GBase 8s（gbasedbtjdbc）SQL 提取。
+ * <p>
+ * 驱动字段名经混淆且跨版本不一致，不能简单 {@code getFieldValue("v")}：
+ * <ul>
+ *   <li>3.6.3：子类 {@code IfxPreparedStatement.v} 为 {@link String}，存原始 SQL</li>
+ *   <li>3.6.5：父类 {@code IfxStatement.v} 为 {@code short}（默认 0），原始 SQL 在子类字段 {@code B}；
+ *       若误读父类 {@code v} 会打印成 {@code 0;}</li>
+ * </ul>
+ * 因此只接受 {@link String} 类型字段，并优先读子类声明字段，再回退 {@code commandString}。
+ *
+ * @author C.
+ */
+final class GbaseSqlSupport {
+
+    private GbaseSqlSupport() {
+    }
+
+    /**
+     * 从 GBase Statement 提取带 {@code ?} 的 SQL 文本。
+     *
+     * @param sta JDBC Statement（通常为 IfxPreparedStatement）
+     * @return SQL 文本；无法提取时回退 {@link Object#toString()}
+     */
+    static String extractSql(Statement sta) {
+        if (sta == null) {
+            return "";
+        }
+        // 子类混淆字段：3.6.5 用 B，3.6.3 用 v（必须限定 String，避开父类 short v）
+        String fromDeclared = findFirstStringField(sta, "B", "v");
+        if (StrUtil.isNotBlank(fromDeclared)) {
+            return fromDeclared;
+        }
+        // 构造时会写入 nativeSQL 结果，两个版本都较稳定
+        Object commandString = ReflectUtil.getFieldValue(sta, "commandString");
+        if (commandString != null && StrUtil.isNotBlank(commandString.toString())) {
+            return commandString.toString();
+        }
+        return sta.toString();
+    }
+
+    /**
+     * 在类继承链上查找指定名称且类型为 String 的字段值。
+     * <p>
+     * 使用 {@link Class#getDeclaredField(String)} 逐级查找，并显式校验类型，
+     * 避免 hutool {@code getFieldValue("v")} 命中父类非 String 字段。
+     */
+    private static String findFirstStringField(Object obj, String... names) {
+        Class<?> type = obj.getClass();
+        while (type != null && type != Object.class) {
+            for (String name : names) {
+                try {
+                    Field field = type.getDeclaredField(name);
+                    if (field.getType() != String.class) {
+                        // 同名但类型不对（如 3.6.5 父类 short v），跳过继续向上找
+                        continue;
+                    }
+                    field.setAccessible(true);
+                    Object value = field.get(obj);
+                    if (value != null && StrUtil.isNotBlank(value.toString())) {
+                        return value.toString();
+                    }
+                } catch (NoSuchFieldException ignored) {
+                    // 当前类没有该字段，尝试下一个名字 / 父类
+                } catch (IllegalAccessException ignored) {
+                    // 不可访问时继续其他候选，避免打断 SQL 打印主流程
+                }
+            }
+            type = type.getSuperclass();
+        }
+        return null;
+    }
+}

--- a/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/JdbcDriverClasses.java
+++ b/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/sql/JdbcDriverClasses.java
@@ -32,6 +32,8 @@ class JdbcDriverClasses {
             {"com.mysql.cj.jdbc.NonRegisteringDriver", "mysql"},
             {"org.postgresql.Driver", "postgresql"},
             {"com.kingbase8.Driver", "kingbase"},
+            // GBase 8s（产品线 gbasedbt / Informix 兼容）JDBC 驱动
+            {"com.gbasedbt.jdbc.Driver", "gbasedbt"},
             {"com.microsoft.sqlserver.jdbc.SQLServerDriver", "sqlserver"},
             {"com.clickhouse.jdbc.Driver", "clickhouse"},
             {"oracle.jdbc.driver.OracleDriver", "oracle"},

--- a/debug-tools-sql/src/test/java/io/github/future0923/debug/tools/sql/GbaseSqlSupportTest.java
+++ b/debug-tools-sql/src/test/java/io/github/future0923/debug/tools/sql/GbaseSqlSupportTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2024-2025 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.github.future0923.debug.tools.sql;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLWarning;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * 覆盖 GBase 驱动跨版本字段布局，防止再出现打印 {@code 0;} 的回归。
+ */
+class GbaseSqlSupportTest {
+
+    @Test
+    void extractSql_from365Layout_shouldPreferStringB_notParentShortV() {
+        // 模拟 3.6.5：父类 short v=0，SQL 在子类 B / commandString
+        Gbase365Statement statement = new Gbase365Statement();
+        statement.v = 0;
+        statement.B = "select * from t where id = ?";
+        statement.commandString = "select * from t where id = ?";
+
+        String sql = GbaseSqlSupport.extractSql(statement);
+
+        assertEquals("select * from t where id = ?", sql);
+        assertFalse("0".equals(sql), "must not read parent short v as SQL");
+    }
+
+    @Test
+    void extractSql_from363Layout_shouldReadChildStringV() {
+        // 模拟 3.6.3：子类 String v 存原始 SQL
+        Gbase363Statement statement = new Gbase363Statement();
+        statement.v = "update user set name = ? where id = ?";
+        statement.commandString = "update user set name = ? where id = ?";
+
+        String sql = GbaseSqlSupport.extractSql(statement);
+
+        assertEquals("update user set name = ? where id = ?", sql);
+    }
+
+    @Test
+    void extractSql_fallbackCommandString_whenObfuscatedFieldMissing() {
+        CommandStringOnlyStatement statement = new CommandStringOnlyStatement();
+        statement.commandString = "select 1 from dual";
+
+        assertEquals("select 1 from dual", GbaseSqlSupport.extractSql(statement));
+    }
+
+    @Test
+    void format_gbasedbt_shouldFillPlaceholders_for365Layout() {
+        Gbase365Statement statement = new Gbase365Statement();
+        statement.v = 0;
+        statement.B = "select * from t where id = ? and name = ?";
+        statement.commandString = "select * from t where id = ? and name = ?";
+
+        String formatted = DataSourceDriverClassEnum.GBASEDBT.getFormat()
+                .format(statement, new Object[]{1, "tom"});
+
+        assertEquals("select * from t where id = 1 and name = 'tom'", formatted);
+    }
+
+    /** 3.6.5 字段布局：父类 short v + 子类 String B */
+    private static class Gbase365Base implements Statement {
+        short v;
+        public String commandString;
+
+        @Override public ResultSet executeQuery(String sql) { return null; }
+        @Override public int executeUpdate(String sql) { return 0; }
+        @Override public void close() { }
+        @Override public int getMaxFieldSize() { return 0; }
+        @Override public void setMaxFieldSize(int max) { }
+        @Override public int getMaxRows() { return 0; }
+        @Override public void setMaxRows(int max) { }
+        @Override public void setEscapeProcessing(boolean enable) { }
+        @Override public int getQueryTimeout() { return 0; }
+        @Override public void setQueryTimeout(int seconds) { }
+        @Override public void cancel() { }
+        @Override public SQLWarning getWarnings() { return null; }
+        @Override public void clearWarnings() { }
+        @Override public void setCursorName(String name) { }
+        @Override public boolean execute(String sql) { return false; }
+        @Override public ResultSet getResultSet() { return null; }
+        @Override public int getUpdateCount() { return 0; }
+        @Override public boolean getMoreResults() { return false; }
+        @Override public void setFetchDirection(int direction) { }
+        @Override public int getFetchDirection() { return 0; }
+        @Override public void setFetchSize(int rows) { }
+        @Override public int getFetchSize() { return 0; }
+        @Override public int getResultSetConcurrency() { return 0; }
+        @Override public int getResultSetType() { return 0; }
+        @Override public void addBatch(String sql) { }
+        @Override public void clearBatch() { }
+        @Override public int[] executeBatch() { return new int[0]; }
+        @Override public Connection getConnection() { return null; }
+        @Override public boolean getMoreResults(int current) { return false; }
+        @Override public ResultSet getGeneratedKeys() { return null; }
+        @Override public int executeUpdate(String sql, int autoGeneratedKeys) { return 0; }
+        @Override public int executeUpdate(String sql, int[] columnIndexes) { return 0; }
+        @Override public int executeUpdate(String sql, String[] columnNames) { return 0; }
+        @Override public boolean execute(String sql, int autoGeneratedKeys) { return false; }
+        @Override public boolean execute(String sql, int[] columnIndexes) { return false; }
+        @Override public boolean execute(String sql, String[] columnNames) { return false; }
+        @Override public int getResultSetHoldability() { return 0; }
+        @Override public boolean isClosed() { return false; }
+        @Override public void setPoolable(boolean poolable) { }
+        @Override public boolean isPoolable() { return false; }
+        @Override public void closeOnCompletion() { }
+        @Override public boolean isCloseOnCompletion() { return false; }
+        @Override public <T> T unwrap(Class<T> iface) { return null; }
+        @Override public boolean isWrapperFor(Class<?> iface) { return false; }
+    }
+
+    private static class Gbase365Statement extends Gbase365Base {
+        String B;
+    }
+
+    /** 3.6.3 字段布局：子类 String v */
+    private static class Gbase363Statement extends Gbase365Base {
+        String v;
+    }
+
+    private static class CommandStringOnlyStatement extends Gbase365Base {
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #298
- 新增 GBase 8s（`gbasedbtjdbc` / `com.gbasedbt.jdbc.Driver`）SQL 打印支持
- 兼容驱动字段混淆差异：3.6.3 子类 `String v`、3.6.5 父类 `short v` + 子类 `String B`，避免误打印 `0;`
- 通过 `GbaseSqlSupport` 提取 SQL 后复用现有参数填充逻辑

## Changes
- `JdbcDriverClasses`：注册 `com.gbasedbt.jdbc.Driver` → `gbasedbt`
- `DataSourceDriverClassEnum`：新增 `GBASEDBT`
- `GbaseSqlSupport`：跨版本安全提取 SQL
- `GbaseSqlSupportTest`：覆盖 3.6.3 / 3.6.5 字段布局与参数替换

## Test plan
- [x] 单元测试 `GbaseSqlSupportTest` 通过
- [x] 本地使用 gbasedbtjdbc 3.6.5 业务应用验证 SQL 打印正常（含参数替换）
- [ ] Reviewer 可按需用 GBase 8s 再验证 select/update/null 参数