### PR TITLE
SQL文件日志里面，末尾不要放2个; #306

### DIFF
--- a/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/utils/SqlFileWriter.java
+++ b/debug-tools-sql/src/main/java/io/github/future0923/debug/tools/utils/SqlFileWriter.java
@@ -61,7 +61,7 @@ public class SqlFileWriter {
             String timeStr = now.format(TIME_FORMATTER);
 
             String content = String.format(
-                    "-- %s | %s | %dms\n%s;\n\n",
+                    "-- %s | %s | %dms\n%s\n\n",
                     timeStr, dbType, consumeTime, sql
             );
 


### PR DESCRIPTION
因为 SqlPrintInterceptor#printSql 已经确保末尾有 ; 了
<img width="1186" height="578" alt="image" src="https://github.com/user-attachments/assets/54fad742-4d64-46be-88fd-5b0d8ee9d151" />
